### PR TITLE
Windows環境でのUnicodeDecodeError対策

### DIFF
--- a/tools/yaml2rst.py
+++ b/tools/yaml2rst.py
@@ -192,7 +192,7 @@ def read_yaml(dir):
     obj = {}
     for src in srcs:
         try:
-            with open(src) as f:
+            with open(src, encoding="utf-8") as f:
                 data = yaml.load(f, Loader=yaml.FullLoader)
         except Exception as e:
             print('Exception occurred while loading YAML...', file=sys.stderr)


### PR DESCRIPTION
Windows環境でyaml2rst.pyを実行したとき、UnicodeDecodeErrorが発生する問題を修正しました。
