### PR TITLE
チェックリストの一部調整

### DIFF
--- a/data/yaml/checks/product/0172.yaml
+++ b/data/yaml/checks/product/0172.yaml
@@ -52,15 +52,16 @@ procedures:
         *  選択状態の移動が、画面表示や表示内容の意味合いから考えて不自然な順序になっていない
         *  画面上に表示されているテキスト、表示されている画像の代替テキスト以外のものが読み上げられることがない
         *  画面上に表示されているもので読み上げられないものがない
-
-        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
       en: |-
         Confirm the following by moving the focus with one-finger left/right flicks:
 
         *  Selected state moves in a natural order that is consistent with displayed content and its meaning.
         *  Nothing besides text displayed on the screen and the alternative text of images being displayed is announced.
         *  Everything displayed on the screen is announced.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
+      en: |-
         CF： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
   - tool: android-tb
     technique:
@@ -70,13 +71,14 @@ procedures:
         *  選択状態の移動が、画面表示や表示内容の意味合いから考えて不自然な順序になっていない
         *  画面上に表示されているテキスト、表示されている画像の代替テキスト以外のものが読み上げられることがない
         *  画面上に表示されているもので読み上げられないものがない
-
-        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
       en: |-
         Confirm the following by moving the focus with one-finger left/right flicks:
 
         *  Selected state moves in a natural order that is consistent with displayed content and its meaning.
         *  Nothing besides text displayed on the screen and the alternative text of images being displayed is announced.
         *  Everything displayed on the screen is announced.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
+      en: |-
         CF： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`

--- a/data/yaml/checks/product/0411.yaml
+++ b/data/yaml/checks/product/0411.yaml
@@ -41,22 +41,24 @@ procedures:
       ja: |-
         *  1本指による右および左方向のフリックでアイコンに到達した際、そのアイコンの役割が分かるようなテキストが読み上げられることを確認する。
         *  （フリックではなく）アイコンに触れたとき、そのアイコンの役割が分かるテキストが読み上げられることを確認する。
-
-        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
       en: |-
         *  Cofirm that text describing the role of the icon is announced when reaching an icon by one-finger left/right flicks.
         *  Cofirm that text describing the role of the icon is announced when an icon is touched, instead of reaching it by flicking.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
   - tool: android-tb
     technique:
       ja: |-
         *  1本指による右および左方向のフリックでアイコンに到達した際、そのアイコンの役割が分かるようなテキストが読み上げられることを確認する。
         *  （フリックではなく）アイコンに触れたとき、そのアイコンの役割が分かるテキストが読み上げられることを確認する。
-
-        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
       en: |-
         *  Cofirm that text describing the role of the icon is announced when reaching an icon by one-finger left/right flicks.
         *  Cofirm that text describing the role of the icon is announced when the icon is touched, instead of reaching it by flicking.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-androidtb-one-finger-horizontal-flick`

--- a/data/yaml/checks/product/0413.yaml
+++ b/data/yaml/checks/product/0413.yaml
@@ -34,19 +34,22 @@ procedures:
     technique:
       ja: |-
         1本指による右および左方向のフリックでフォーカスを移動して当該のアイコンとテキスト・ラベルがある箇所を通過したとき、アイコンとそのアイコンに併記されているテキストの両方が読み上げられるなど、結果として同じ内容が2度読まれるような状態になっていないことを確認する。
-
-        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
       en: |-
         Confirm that the same content is not announced twice as the result of both the icon and the accompanying text being announced, when passing over a location with an icon accompanied by a text label using one-finger left/right flicks.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
   - tool: android-tb
     technique:
       ja: |-
         1本指による右および左方向のフリックでフォーカスを移動して当該のアイコンとテキスト・ラベルがある箇所を通過したとき、アイコンとそのアイコンに併記されているテキストの両方が読み上げられるなど、結果として同じ内容が2度読まれるような状態になっていないことを確認する。
-
-        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
       en: |-
         Confirm that the same content is not announced twice as the result of both the icon and the accompanying text being announced, when passing over a location with an icon accompanied by a text label using one-finger left/right flicks.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
+

--- a/data/yaml/checks/product/0441.yaml
+++ b/data/yaml/checks/product/0441.yaml
@@ -17,6 +17,16 @@ procedures:
     en: |-
       Confirm the following checks by axe DevTools and NVDA pass.
   techniques:
+  - tool: axe
+    technique:
+      ja: |-
+        「 :ref:`axe-rule-image-alt` 」という問題が出ないことを確認する。
+      
+        ただし、画像に何かしらの代替テキストが入っていれば問題として検知されないため、適切ではない代替テキストの検出をすることはできません。
+      en: |-
+        Confirm that the issue :ref:`axe-rule-image-alt` is not reported.
+      
+        Note that this issue is not reported if any alternative text is specified for the image, and it is not possible to detect if the alternative text is inappropriate.
   - tool: nvda
     technique:
       ja: |-
@@ -39,16 +49,6 @@ procedures:
         
           -  Detailed description is placed immediately before or after the image, and it is announced when using arrow keys in browse mode.
           -  Detailed description is announced when using the go to next/previous image function (G/Shift+G) in browse mode.
-  - tool: axe
-    technique:
-      ja: |-
-        「 :ref:`axe-rule-image-alt` 」という問題が出ないことを確認する。
-      
-        ただし、画像に何かしらの代替テキストが入っていれば問題として検知されないため、適切ではない代替テキストの検出をすることはできません。
-      en: |-
-        Confirm that the issue :ref:`axe-rule-image-alt` is not reported.
-      
-        Note that this issue is not reported if any alternative text is specified for the image, and it is not possible to detect if the alternative text is inappropriate.
 - platform: mobile
   procedure:
     ja: |-

--- a/data/yaml/checks/product/0441.yaml
+++ b/data/yaml/checks/product/0441.yaml
@@ -61,22 +61,24 @@ procedures:
       ja: |-
         *  1本指による右および左方向のフリックで画像に到達した際、その画像の意味が分かるようなテキストが読み上げられることを確認する。
         *  （フリックではなく）画像に触れたとき、その画像の意味が分かるテキストが読み上げられることを確認するる。
-
-        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
       en: |-
         *  Cofirm that text describing the meaning of the image is announced when reaching an image by one-finger left/right flicks.
         *  Cofirm that text describing the meaning of the image is announced when an image is touched, instead of reaching it by flicking.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
   - tool: android-tb
     technique:
       ja: |-
         *  1本指による右および左方向のフリックで画像に到達した際、その画像の意味が分かるようなテキストが読み上げられることを確認する。
         *  （フリックではなく）画像に触れたとき、その画像の意味が分かるテキストが読み上げられることを確認する。
-
-        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
       en: |-
         *  Cofirm that text describing the meaning of the image is announced when reaching an image by one-finger left/right flicks.
         *  Cofirm that text describing the meaning of the image is announced when an image is touched, instead of reaching it by flicking.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-androidtb-one-finger-horizontal-flick`

--- a/data/yaml/checks/product/0471.yaml
+++ b/data/yaml/checks/product/0471.yaml
@@ -34,19 +34,21 @@ procedures:
     technique:
       ja: |-
         1本指による右および左方向のフリックでフォーカスを移動した際、当該の画像が無視されて読み上げられないことを確認する。
-
-        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
       en: |-
         Confirm that the image is ignored and nothing is announced when moving the focus by one-finger left/right flicks.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
   - tool: android-tb
     technique:
       ja: |-
         1本指による右および左方向のフリックでフォーカスを移動した際、当該の画像が無視されて読み上げられないことを確認する。
-
-        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
       en: |-
         Confirm that the image is ignored and nothing is announced when moving the focus by one-finger left/right flicks.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-androidtb-one-finger-horizontal-flick`

--- a/data/yaml/checks/product/0531.yaml
+++ b/data/yaml/checks/product/0531.yaml
@@ -35,22 +35,24 @@ procedures:
       ja: |-
         *  1本指による右および左方向のフリックで画像に到達した際、画像に含まれるテキストと同じ内容が読み上げられることを確認する。
         *  （フリックではなく）画像に触れたとき、画像に含まれるテキストと同じ内容が読み上げられることを確認する。
-
-        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
       en: |-
         *  Cofirm that the same text as contained in the image is announced when reaching the image by one-finger left/right flicks.
         *  Cofirm that the same text as contained in the image is announced when the image is touched, instead of reaching it by flicking.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
   - tool: android-tb
     technique:
       ja: |-
         *  1本指による右および左方向のフリックで画像に到達した際、画像に含まれるテキストと同じ内容が読み上げられることを確認する。
         *  （フリックではなく）画像に触れたとき、画像に含まれるテキストと同じ内容が読み上げられることを確認する。
-
-        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
       en: |-
         *  Cofirm that the same text as contained in the image is announced when reaching the image by one-finger left/right flicks.
         *  Cofirm that the same text as contained in the image is announced when the image is touched, instead of reaching it by flicking.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-androidtb-one-finger-horizontal-flick`

--- a/data/yaml/checks/product/0561.yaml
+++ b/data/yaml/checks/product/0561.yaml
@@ -17,18 +17,6 @@ procedures:
     en: |-
       Confirm the following checks by axe DevTools and NVDA pass.
   techniques:
-  - tool: nvda
-    technique:
-      ja: |-
-        以下の手順で見出しリストを表示して、ページ中の見出しが過不足なく表示されていることを確認する。
-
-        1. ブラウズ・モードで要素リストを表示（ :kbd:`NVDA+F7` ）
-        2. 「種別」を「見出し」に設定（ :kbd:`Alt+H` ）
-      en: |-
-        Display the heading list by steps below, and confirm that all headings on the page are displayed appropriately.
-
-        1. Display the elements list in browse mode (:kbd:`NVDA+F7`)
-        2. Set the "Type" to "Headings" ():kbd:`Alt+H`)
   - tool: axe
     technique:
       ja: |-
@@ -43,6 +31,18 @@ procedures:
         *  :ref:`axe-rule-empty-heading`
         *  :ref:`axe-rule-heading-order`
         *  :ref:`axe-rule-page-has-heading-one`
+  - tool: nvda
+    technique:
+      ja: |-
+        以下の手順で見出しリストを表示して、ページ中の見出しが過不足なく表示されていることを確認する。
+
+        1. ブラウズ・モードで要素リストを表示（ :kbd:`NVDA+F7` ）
+        2. 「種別」を「見出し」に設定（ :kbd:`Alt+H` ）
+      en: |-
+        Display the heading list by steps below, and confirm that all headings on the page are displayed appropriately.
+
+        1. Display the elements list in browse mode (:kbd:`NVDA+F7`)
+        2. Set the "Type" to "Headings" ():kbd:`Alt+H`)
 - platform: mobile
   procedure:
     ja: |-

--- a/data/yaml/checks/product/0561.yaml
+++ b/data/yaml/checks/product/0561.yaml
@@ -54,19 +54,21 @@ procedures:
     technique:
       ja: |-
         ローター・ジェスチャーで「見出し」を選んだ上で、1本指の下および上方向のフリックですべての見出しに到達できることを確認する。
-
-        参考： :ref:`exp-sr-iosvo-one-finger-vertical-flick`
       en: |-
         Confirm that all the headings can be reached by one-finger up/down flicks after choosing `headings` by the rotor gesture.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-iosvo-one-finger-vertical-flick`
+      en: |-
         CF: :ref:`exp-sr-iosvo-one-finger-vertical-flick`
   - tool: android-tb
     technique:
       ja: |-
         読み上げコントロールの設定で「見出し」を選んだ上で、1本指の下および上方向のフリックですべての見出しに到達できることを確認する。
-
-        参考： :ref:`exp-sr-androidtb-one-finger-vertical-flick`
       en: |-
         Confirm that all the headings can be reached by one-finger up/down flicks after choosing `headings` for reading controls.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-androidtb-one-finger-vertical-flick`
+      en: |-
         CF: :ref:`exp-sr-androidtb-one-finger-vertical-flick`

--- a/data/yaml/checks/product/0621.yaml
+++ b/data/yaml/checks/product/0621.yaml
@@ -16,17 +16,6 @@ procedures:
     en: |-
       Confirm the following checks by axe DevTools and NVDA pass.
   techniques:
-  - tool: nvda
-    technique:
-      ja: |-
-        ブラウズ・モードで上下矢印キーを用いて読み上げさせたとき、表示されているテキストが問題なく読み上げられることを確認する。
-      en: |-
-        Confirm that displayed text is announced without any issue when reading with up and down arrow keys in browse mode.
-    note:
-      ja: |-
-        このチェックを正しく実施するためには、多言語処理のための設定を行う必要があります。（ :ref:`exp-screen-reader-check` の「その他の初期設定」、「音声」および「音声合成エンジンの管理」の項を参照）
-      en: |-
-        To perform this check properly, the settings need to be done for processing multiple languages.
   - tool: axe
     technique:
       ja: |-
@@ -38,3 +27,14 @@ procedures:
         この問題が出た場合は、そのページの ``<html>`` 要素の記述を ``<html lang="ja">`` （主に利用されている言語が日本語の場合）のように修正する必要があります。
       en: |-
         If this issue is reported, the ``<html>`` element of the page needs to be modified such as ``<html lang="ja">`` (in the case where the primary language of the page being Japanese)
+  - tool: nvda
+    technique:
+      ja: |-
+        ブラウズ・モードで上下矢印キーを用いて読み上げさせたとき、表示されているテキストが問題なく読み上げられることを確認する。
+      en: |-
+        Confirm that displayed text is announced without any issue when reading with up and down arrow keys in browse mode.
+    note:
+      ja: |-
+        このチェックを正しく実施するためには、多言語処理のための設定を行う必要があります。（ :ref:`exp-screen-reader-check` の「その他の初期設定」、「音声」および「音声合成エンジンの管理」の項を参照）
+      en: |-
+        To perform this check properly, the settings need to be done for processing multiple languages.

--- a/data/yaml/checks/product/0711.yaml
+++ b/data/yaml/checks/product/0711.yaml
@@ -37,22 +37,24 @@ procedures:
       ja: |-
         *  1本指による右および左方向のフリックでフォーカスを移動した際、自然な、意味の理解を阻害しない順序で読み上げられることを確認する。
         *  別の画面への遷移を伴わずに表示内容を変更するような仕組みがある場合は、すべての状態において適切な順序で読み上げられることを確認する。
-
-        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
       en: |-
         *  Confirm that the content is read aloud in an order which is natural, and does not hinder the understanding of the meaning when moving the focus with one-finger left/right flicks.
         *  Confirm that the content is read aloud in the appropriate order in all states when there are mechanisms that change the display content without transitioning to another page.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
   - tool: android-tb
     technique:
       ja: |-
         *  1本指による右および左方向のフリックでフォーカスを移動した際、自然な、意味の理解を阻害しない順序で読み上げられることを確認する。
         *  別の画面への遷移を伴わずに表示内容を変更するような仕組みがある場合は、すべての状態において適切な順序で読み上げられることを確認する。
-
-        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
       en: |-
         *  Confirm that the content is read aloud in an order which is natural, and does not hinder the understanding of the meaning when moving the focus with one-finger left/right flicks.
         *  Confirm that the content is read aloud in the appropriate order in all states when there are mechanisms that change the display content without transitioning to another page.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-androidtb-one-finger-horizontal-flick`

--- a/data/yaml/checks/product/0801.yaml
+++ b/data/yaml/checks/product/0801.yaml
@@ -42,19 +42,21 @@ procedures:
     technique:
       ja: |-
         1本指による右および左方向のフリックでフォーカスを移動した際の読み上げ順序が、複数の画面一貫していることを確認する。
-
-        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
       en: |-
         Confirm that the reading order is consistent across multiple screens when moving the focus using one-finger left/right flicks.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-iosvo-one-finger-horizontal-flick`
   - tool: android-tb
     technique:
       ja: |-
         1本指による右および左方向のフリックでフォーカスを移動した際の読み上げ順序が、複数の画面で一貫していることを確認する。
-
-        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
       en: |-
         Confirm that the reading order is consistent across multiple screens when moving the focus using one-finger left/right flicks.
-
+    note:
+      ja: |-
+        参考： :ref:`exp-sr-androidtb-one-finger-horizontal-flick`
+      en: |-
         CF: :ref:`exp-sr-androidtb-one-finger-horizontal-flick`


### PR DESCRIPTION
- チェック手順でのaxeとNVDAの表記順序を統一 （axe→NVDA）
- チェック方法例内の参考リンクをチェックシートに表示しないようにする修正
