### PR TITLE
yaml2rstの改善とテンプレートの共通部分の切り出し

### DIFF
--- a/tools/yaml2rst/templates/allchecks.rst
+++ b/tools/yaml2rst/templates/allchecks.rst
@@ -1,7 +1,8 @@
+{%- set check_heading_level = 2 -%}
 {% for check in allchecks -%}
 .. _check-{{ check.id }}:
 
-{% filter make_header('*', True) -%}
+{% filter make_heading(2) -%}
 チェックID：{{ check.id }}
 {%- endfilter %}
 
@@ -20,7 +21,7 @@
 {{ check.check }}
 
 {% if check.inforefs is defined -%}
-{% filter make_header('=') -%}
+{% filter make_heading(3) -%}
 参考情報
 {%- endfilter %}
 
@@ -30,39 +31,9 @@
 {%- endif %}
 
 {% if check.implementations is defined -%}
-{% for impl in check.implementations -%}
-{% filter make_header('=') -%}
-実装方法の例：{{ impl.title }}
-{%- endfilter %}
-
-{% for ex in impl.examples -%}
-{{ ex.platform }}
-   {{ ex.method | indent(3) }}
-
-{% endfor %}
-{%- endfor %}
+{% include 'check-implementation.rst' %}
 {%- endif %}
 {% if check.procedures is defined %}
-{% for proc in check.procedures -%}
-{% filter make_header('=') -%}
-チェック手順： {{ proc.platform }}
-{%- endfilter %}
-
-{{ proc.text }}
-
-{% if proc.techniques is defined -%}
-
-{% for technique in proc.techniques -%}
-{% filter make_header('-') -%}
-{{ technique.tool_display_name }}によるチェック方法の例
-{%- endfilter %}
-
-{{ technique.technique }}
-{% if technique.note is defined %}
-{{ technique.note }}
-{% endif %}
-{% endfor %}
-{%- endif %}
-{%- endfor %}
+{% include 'check-procedure.rst' %}
 {% endif %}
 {%- endfor %}

--- a/tools/yaml2rst/templates/check-examples-tool.rst
+++ b/tools/yaml2rst/templates/check-examples-tool.rst
@@ -1,7 +1,7 @@
 {% for ex in examples -%}
 .. _check-example-{{ ex.tool }}-{{ ex.id }}:
 
-{% filter make_header('*', True) -%}
+{% filter make_heading(2) -%}
 :ref:`check-{{ ex.id }}`
 {%- endfilter %}
 

--- a/tools/yaml2rst/templates/check-implementation.rst
+++ b/tools/yaml2rst/templates/check-implementation.rst
@@ -1,0 +1,10 @@
+{% for impl in check.implementations -%}
+{% filter make_heading(check_heading_level + 1) -%}
+実装方法の例：{{ impl.title }}
+{%- endfilter %}
+
+{% for ex in impl.examples -%}
+{{ ex.platform }}
+   {{ ex.method | indent(3) }}
+{% endfor %}
+{% endfor %}

--- a/tools/yaml2rst/templates/check-procedure.rst
+++ b/tools/yaml2rst/templates/check-procedure.rst
@@ -1,0 +1,21 @@
+{% for proc in check.procedures -%}
+{% filter make_heading(check_heading_level + 1) -%}
+チェック手順： {{ proc.platform }}
+{%- endfilter %}
+
+{{ proc.text }}
+
+{% if proc.techniques is defined -%}
+
+{% for technique in proc.techniques -%}
+{% filter make_heading(check_heading_level + 2) -%}
+{{ technique.tool_display_name }}によるチェック方法の例
+{%- endfilter %}
+
+{{ technique.technique }}
+{% if technique.note is defined %}
+{{ technique.note }}
+{% endif %}
+{% endfor %}
+{%- endif %}
+{%- endfor %}

--- a/tools/yaml2rst/templates/gl-category-id.rst
+++ b/tools/yaml2rst/templates/gl-category-id.rst
@@ -1,6 +1,7 @@
+{%- set check_heading_level = 4 -%}
 .. _{{ id }}:
 
-{{ title|make_header("*", True) }}
+{{ title|make_heading(2) }}
 
 優先度
    {{ priority }}
@@ -9,13 +10,13 @@
 
 {{ guideline }}
 
-{% filter make_header('=') -%}
+{% filter make_heading(3) -%}
 意図
 {%- endfilter %}
 
 {{ intent }}
 
-{% filter make_header('=') -%}
+{% filter make_heading(3) -%}
 対応するWCAG 2.1の達成基準
 {%- endfilter %}
 
@@ -26,7 +27,7 @@ SC {{ sc.sc }}：
 {% endfor %}
 
 {% if info is defined -%}
-{% filter make_header('=') -%}
+{% filter make_heading(3) -%}
 参考情報
 {%- endfilter %}
 
@@ -35,12 +36,12 @@ SC {{ sc.sc }}：
 {% endfor %}
 {%- endif %}
 
-{% filter make_header('=', False, 'checklist') -%}
+{% filter make_heading(3, 'checklist') -%}
 チェック内容
 {%- endfilter %}
 
 {% for check in checks -%}
-{% filter make_header('-') -%}
+{% filter make_heading(4) -%}
 :ref:`check-{{ check.id }}`
 {%- endfilter %}
 
@@ -51,44 +52,13 @@ SC {{ sc.sc }}：
 重篤度
    {{ check.severity }}
 
-
 {{ check.check }}
 
 {% if check.implementations is defined -%}
-{% for impl in check.implementations -%}
-{% filter make_header('^') -%}
-実装方法の例：{{ impl.title }}
-{%- endfilter %}
-
-{% for ex in impl.examples -%}
-{{ ex.platform }}
-   {{ ex.method | indent(3) }}
-
-{% endfor %}
-{%- endfor %}
+{% include 'check-implementation.rst' %}
 {%- endif %}
 {% if check.procedures is defined %}
-{% for proc in check.procedures -%}
-{% filter make_header('^') -%}
-チェック手順： {{ proc.platform }}
-{%- endfilter %}
-
-{{ proc.text }}
-
-{% if proc.techniques is defined -%}
-
-{% for technique in proc.techniques -%}
-{% filter make_header('"') -%}
-{{ technique.tool_display_name }}によるチェック方法の例
-{%- endfilter %}
-
-{{ technique.technique }}
-{% if technique.note is defined %}
-{{ technique.note }}
-{% endif %}
-{% endfor %}
-{%- endif %}
-{%- endfor %}
+{% include 'check-procedure.rst' %}
 {% endif %}
 
 {%- endfor %}


### PR DESCRIPTION
* 前チェック一覧とガイドラインのテンプレートの共通部分を切り出して別ファイルに分離
* それに伴って必要だった yaml2rst.py の変更
