### PR TITLE
yaml2rst.pyで、カテゴリーごとのページを生成する

### DIFF
--- a/source/categories/dynamic_content.rst
+++ b/source/categories/dynamic_content.rst
@@ -13,12 +13,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-dynamic-content-maintain-dom-tree.rst
-.. include:: /inc/gl-dynamic-content-focus.rst
-.. include:: /inc/gl-dynamic-content-hover-magnify.rst
-.. include:: /inc/gl-dynamic-content-hover.rst
-.. include:: /inc/gl-dynamic-content-status.rst
-.. include:: /inc/gl-dynamic-content-pause-movement.rst
-.. include:: /inc/gl-dynamic-content-pause-refresh.rst
-.. include:: /inc/gl-dynamic-content-no-flashing.rst
-.. include:: /inc/gl-dynamic-content-no-interrupt.rst
+.. include:: /inc/gl-category-dynamic_content.rst

--- a/source/categories/form.rst
+++ b/source/categories/form.rst
@@ -11,17 +11,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-form-label.rst
-.. include:: /inc/gl-form-hidden-label.rst
-.. include:: /inc/gl-form-color-only.rst
-.. include:: /inc/gl-form-timing.rst
-.. include:: /inc/gl-form-no-timing.rst
-.. include:: /inc/gl-form-continue.rst
-.. include:: /inc/gl-form-tab-order.rst
-.. include:: /inc/gl-form-dynamic-content-focus.rst
-.. include:: /inc/gl-form-dynamic-content-change.rst
-.. include:: /inc/gl-form-errors-identify.rst
-.. include:: /inc/gl-form-errors-correction.rst
-.. include:: /inc/gl-form-errors-cancel.rst
-.. include:: /inc/gl-form-target-size.rst
-.. include:: /inc/gl-form-target-size-mobile.rst
+.. include:: /inc/gl-category-form.rst

--- a/source/categories/icon.rst
+++ b/source/categories/icon.rst
@@ -16,9 +16,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-icon-visible-label.rst
-.. include:: /inc/gl-icon-color-only.rst
-.. include:: /inc/gl-icon-consistent.rst
-.. include:: /inc/gl-icon-contrast.rst
-.. include:: /inc/gl-icon-target-size.rst
-.. include:: /inc/gl-icon-target-size-mobile.rst
+.. include:: /inc/gl-category-icon.rst

--- a/source/categories/image.rst
+++ b/source/categories/image.rst
@@ -12,8 +12,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-image-description.rst
-.. include:: /inc/gl-image-decorative.rst
-.. include:: /inc/gl-image-color-only.rst
-.. include:: /inc/gl-image-adjacent-contrast.rst
-.. include:: /inc/gl-image-text-contrast.rst
+.. include:: /inc/gl-category-image.rst

--- a/source/categories/images_of_text.rst
+++ b/source/categories/images_of_text.rst
@@ -15,6 +15,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-iot-avoid-usage.rst
-.. include:: /inc/gl-iot-provide-text.rst
-.. include:: /inc/gl-iot-text-contrast.rst
+.. include:: /inc/gl-category-images_of_text.rst

--- a/source/categories/input_device.rst
+++ b/source/categories/input_device.rst
@@ -11,11 +11,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-input-device-keyboard-operable.rst
-.. include:: /inc/gl-input-device-support-mobile-assistive-tech.rst
-.. include:: /inc/gl-input-device-focus.rst
-.. include:: /inc/gl-input-device-focus-indicator.rst
-.. include:: /inc/gl-input-device-no-trap.rst
-.. include:: /inc/gl-input-device-use-up-event.rst
-.. include:: /inc/gl-input-device-independent.rst
-.. include:: /inc/gl-input-device-shortcut-keys.rst
+.. include:: /inc/gl-category-input_device.rst

--- a/source/categories/link.rst
+++ b/source/categories/link.rst
@@ -15,7 +15,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-link-color-only.rst
-.. include:: /inc/gl-link-text.rst
-.. include:: /inc/gl-link-consistent-text.rst
-.. include:: /inc/gl-link-tab-order.rst
+.. include:: /inc/gl-category-link.rst

--- a/source/categories/login_session.rst
+++ b/source/categories/login_session.rst
@@ -11,6 +11,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-login-session-timing.rst
-.. include:: /inc/gl-login-session-no-timing.rst
-.. include:: /inc/gl-login-session-continue.rst
+.. include:: /inc/gl-category-login_session.rst

--- a/source/categories/markup.rst
+++ b/source/categories/markup.rst
@@ -13,7 +13,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-markup-semantics.rst
-.. include:: /inc/gl-markup-valid.rst
-.. include:: /inc/gl-markup-component-implementation.rst
-.. include:: /inc/gl-markup-component.rst
+.. include:: /inc/gl-category-markup.rst

--- a/source/categories/multimedia.rst
+++ b/source/categories/multimedia.rst
@@ -11,14 +11,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-multimedia-perceivable.rst
-.. include:: /inc/gl-multimedia-operable.rst
-.. include:: /inc/gl-multimedia-pause-movement.rst
-.. include:: /inc/gl-multimedia-no-trap.rst
-.. include:: /inc/gl-multimedia-text-alternative.rst
-.. include:: /inc/gl-multimedia-caption.rst
-.. include:: /inc/gl-multimedia-transcript.rst
-.. include:: /inc/gl-multimedia-video-description.rst
-.. include:: /inc/gl-multimedia-video-description-no-exception.rst
-.. include:: /inc/gl-multimedia-sign-language.rst
-.. include:: /inc/gl-multimedia-background-sound.rst
+.. include:: /inc/gl-category-multimedia.rst

--- a/source/categories/page.rst
+++ b/source/categories/page.rst
@@ -11,12 +11,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-page-title.rst
-.. include:: /inc/gl-page-landmark.rst
-.. include:: /inc/gl-page-markup-main.rst
-.. include:: /inc/gl-page-markup-order.rst
-.. include:: /inc/gl-page-headings.rst
-.. include:: /inc/gl-page-orientation.rst
-.. include:: /inc/gl-page-consistent-navigation.rst
-.. include:: /inc/gl-page-redundant-navigation.rst
-.. include:: /inc/gl-page-location.rst
+.. include:: /inc/gl-category-page.rst

--- a/source/categories/text.rst
+++ b/source/categories/text.rst
@@ -11,16 +11,4 @@
    :local:
    :backlinks: none
 
-.. include:: /inc/gl-text-multiple-modality.rst
-.. include:: /inc/gl-text-color-only.rst
-.. include:: /inc/gl-text-heading-label.rst
-.. include:: /inc/gl-text-page-lang.rst
-.. include:: /inc/gl-text-phrase-lang.rst
-.. include:: /inc/gl-text-component-lang.rst
-.. include:: /inc/gl-text-zoom.rst
-.. include:: /inc/gl-text-enlarge-settings.rst
-.. include:: /inc/gl-text-mobile-enlarge-settings.rst
-.. include:: /inc/gl-text-enable-enlarge.rst
-.. include:: /inc/gl-text-zoom-reflow.rst
-.. include:: /inc/gl-text-customize.rst
-.. include:: /inc/gl-text-contrast.rst
+.. include:: /inc/gl-category-text.rst

--- a/tools/yaml2rst/templates/gl-category.rst
+++ b/tools/yaml2rst/templates/gl-category.rst
@@ -1,37 +1,38 @@
 {%- set check_heading_level = 4 -%}
-.. _{{ id }}:
+{% for gl in guidelines -%}
+.. _{{ gl.id }}:
 
-{{ title|make_heading(2) }}
+{{ gl.title|make_heading(2) }}
 
 優先度
-   {{ priority }}
+   {{ gl.priority }}
 対象プラットフォーム
-   {{ platform }}
+   {{ gl.platform }}
 
-{{ guideline }}
+{{ gl.guideline }}
 
 {% filter make_heading(3) -%}
 意図
 {%- endfilter %}
 
-{{ intent }}
+{{ gl.intent }}
 
 {% filter make_heading(3) -%}
 対応するWCAG 2.1の達成基準
 {%- endfilter %}
 
-{% for sc in scs -%}
+{% for sc in gl.scs -%}
 SC {{ sc.sc }}：
    -  {{ sc.sc_en }}
    -  {{ sc.sc_ja }}
 {% endfor %}
 
-{% if info is defined -%}
+{% if gl.info is defined -%}
 {% filter make_heading(3) -%}
 参考情報
 {%- endfilter %}
 
-{% for item in info -%}
+{% for item in gl.info -%}
 *  {{ item }}
 {% endfor %}
 {%- endif %}
@@ -40,7 +41,7 @@ SC {{ sc.sc }}：
 チェック内容
 {%- endfilter %}
 
-{% for check in checks -%}
+{% for check in gl.checks -%}
 {% filter make_heading(4) -%}
 :ref:`check-{{ check.id }}`
 {%- endfilter %}
@@ -62,3 +63,6 @@ SC {{ sc.sc }}：
 {% endif %}
 
 {%- endfor %}
+
+{% endfor %}
+

--- a/tools/yaml2rst/templates/incfiles.mk
+++ b/tools/yaml2rst/templates/incfiles.mk
@@ -1,6 +1,6 @@
-guidelines_rst = {{ guidelines_rst }}
+guideline_category_rst = {{ guideline_category_rst }}
 
-incfiles: $(guidelines_rst) {{ wcag_mapping_target }} {{ all_checks_target }} {{ priority_diff_target }} {{ miscdefs_target }}
+incfiles: $(guideline_category_rst) {{ wcag_mapping_target }} {{ all_checks_target }} {{ priority_diff_target }} {{ miscdefs_target }}
 
 %.yaml: ;
 %.json: ;


### PR DESCRIPTION
yaml2rst.pyで、ガイドラインごとではなくカテゴリーごとのページを生成するように変更。
これにより、ガイドラインが増えたり減ったりしたりした場合に、YAMLを追加/削除するだけでよくなる。（現在はsource/categories/以下のファイルの変更も必要）
