### PR TITLE
jsonschemaの最新版での仕様変更によるエラーや警告を暫定的に回避

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ sphinx >= 3.0
 sphinx_rtd_theme
 sphinxcontrib-trimblank
 pyyaml
-jsonschema
+jsonschema < 4.18.0

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -89,7 +89,7 @@ def main():
             print(e, file=sys.stderr)
             sys.exit(1)
 
-        schema_path = 'file://{}'.format(os.path.join(os.getcwd(), SCHEMA_SRCDIR))
+        schema_path = 'file://{}/'.format(os.path.join(os.getcwd(), SCHEMA_SRCDIR))
         resolver = RefResolver(schema_path, common_schema)
 
     files = ls_dir(os.path.join(os.getcwd(), GUIDELINES_SRCDIR))


### PR DESCRIPTION
- jsonschemaの仕様変更で警告やエラーが出るようになったので、暫定的に < 4.18.0 を利用
- RefResolverのbase_uriの指定を修正
