### PR TITLE
ガイドラインの優先度とチェック内容の重篤度のYAML中の記述形式の変更

### DIFF
--- a/data/json/schemas/check.json
+++ b/data/json/schemas/check.json
@@ -17,10 +17,10 @@
     "severity": {
       "description": "severity of the issue if the check fails",
       "enum": [
-        "[CRITICAL]",
-        "[MAJOR]",
-        "[NORMAL]",
-        "[MINOR]"
+        "critical",
+        "major",
+        "normal",
+        "minor"
       ]
     },
     "target": {

--- a/data/json/schemas/guideline.json
+++ b/data/json/schemas/guideline.json
@@ -40,8 +40,8 @@
     "priority": {
       "description": "priority of the guideline",
       "enum": [
-        "[MUST]",
-        "[SHOULD]"
+        "must",
+        "should"
       ]
     },
     "platform": {

--- a/data/yaml/checks/code/0071.yaml
+++ b/data/yaml/checks/code/0071.yaml
@@ -1,5 +1,5 @@
 id: '0071'
-severity: '[NORMAL]'
+severity: normal
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0311.yaml
+++ b/data/yaml/checks/code/0311.yaml
@@ -1,5 +1,5 @@
 id: '0311'
-severity: '[NORMAL]'
+severity: normal
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0371.yaml
+++ b/data/yaml/checks/code/0371.yaml
@@ -1,5 +1,5 @@
 id: '0371'
-severity: '[MAJOR]'
+severity: major
 target: code
 platform:
 - mobile

--- a/data/yaml/checks/code/0401.yaml
+++ b/data/yaml/checks/code/0401.yaml
@@ -1,5 +1,5 @@
 id: '0401'
-severity: '[MAJOR]'
+severity: major
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0402.yaml
+++ b/data/yaml/checks/code/0402.yaml
@@ -1,5 +1,5 @@
 id: '0402'
-severity: '[NORMAL]'
+severity: normal
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0431.yaml
+++ b/data/yaml/checks/code/0431.yaml
@@ -1,5 +1,5 @@
 id: '0431'
-severity: '[MAJOR]'
+severity: major
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0461.yaml
+++ b/data/yaml/checks/code/0461.yaml
@@ -1,5 +1,5 @@
 id: '0461'
-severity: '[NORMAL]'
+severity: normal
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0521.yaml
+++ b/data/yaml/checks/code/0521.yaml
@@ -1,5 +1,5 @@
 id: '0521'
-severity: '[MAJOR]'
+severity: major
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0551.yaml
+++ b/data/yaml/checks/code/0551.yaml
@@ -1,5 +1,5 @@
 id: '0551'
-severity: '[NORMAL]'
+severity: normal
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0552.yaml
+++ b/data/yaml/checks/code/0552.yaml
@@ -1,5 +1,5 @@
 id: '0552'
-severity: '[MAJOR]'
+severity: major
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0553.yaml
+++ b/data/yaml/checks/code/0553.yaml
@@ -1,5 +1,5 @@
 id: '0553'
-severity: '[MAJOR]'
+severity: major
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0554.yaml
+++ b/data/yaml/checks/code/0554.yaml
@@ -1,5 +1,5 @@
 id: '0554'
-severity: '[MAJOR]'
+severity: major
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0571.yaml
+++ b/data/yaml/checks/code/0571.yaml
@@ -1,5 +1,5 @@
 id: '0571'
-severity: '[MAJOR]'
+severity: major
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0586.yaml
+++ b/data/yaml/checks/code/0586.yaml
@@ -1,5 +1,5 @@
 id: '0586'
-severity: '[CRITICAL]'
+severity: critical
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0587.yaml
+++ b/data/yaml/checks/code/0587.yaml
@@ -1,5 +1,5 @@
 id: '0587'
-severity: '[CRITICAL]'
+severity: critical
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0611.yaml
+++ b/data/yaml/checks/code/0611.yaml
@@ -1,5 +1,5 @@
 id: '0611'
-severity: '[CRITICAL]'
+severity: critical
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0671.yaml
+++ b/data/yaml/checks/code/0671.yaml
@@ -1,5 +1,5 @@
 id: '0671'
-severity: '[NORMAL]'
+severity: normal
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0672.yaml
+++ b/data/yaml/checks/code/0672.yaml
@@ -1,5 +1,5 @@
 id: '0672'
-severity: '[NORMAL]'
+severity: normal
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0851.yaml
+++ b/data/yaml/checks/code/0851.yaml
@@ -1,5 +1,5 @@
 id: '0851'
-severity: '[NORMAL]'
+severity: normal
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0911.yaml
+++ b/data/yaml/checks/code/0911.yaml
@@ -1,5 +1,5 @@
 id: '0911'
-severity: '[MINOR]'
+severity: minor
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0912.yaml
+++ b/data/yaml/checks/code/0912.yaml
@@ -1,5 +1,5 @@
 id: '0912'
-severity: '[MINOR]'
+severity: minor
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/0941.yaml
+++ b/data/yaml/checks/code/0941.yaml
@@ -1,5 +1,5 @@
 id: '0941'
-severity: '[MAJOR]'
+severity: major
 target: code
 platform:
 - web

--- a/data/yaml/checks/code/1181.yaml
+++ b/data/yaml/checks/code/1181.yaml
@@ -1,5 +1,5 @@
 id: '1181'
-severity: '[MAJOR]'
+severity: major
 target: code
 platform:
 - web

--- a/data/yaml/checks/design/0001.yaml
+++ b/data/yaml/checks/design/0001.yaml
@@ -1,5 +1,5 @@
 id: '0001'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0002.yaml
+++ b/data/yaml/checks/design/0002.yaml
@@ -1,5 +1,5 @@
 id: '0002'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0003.yaml
+++ b/data/yaml/checks/design/0003.yaml
@@ -1,5 +1,5 @@
 id: '0003'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - mobile

--- a/data/yaml/checks/design/0031.yaml
+++ b/data/yaml/checks/design/0031.yaml
@@ -1,5 +1,5 @@
 id: '0031'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0032.yaml
+++ b/data/yaml/checks/design/0032.yaml
@@ -1,5 +1,5 @@
 id: '0032'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0091.yaml
+++ b/data/yaml/checks/design/0091.yaml
@@ -1,5 +1,5 @@
 id: '0091'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0092.yaml
+++ b/data/yaml/checks/design/0092.yaml
@@ -1,5 +1,5 @@
 id: '0092'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0151.yaml
+++ b/data/yaml/checks/design/0151.yaml
@@ -1,5 +1,5 @@
 id: '0151'
-severity: '[CRITICAL]'
+severity: critical
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0152.yaml
+++ b/data/yaml/checks/design/0152.yaml
@@ -1,5 +1,5 @@
 id: '0152'
-severity: '[CRITICAL]'
+severity: critical
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0153.yaml
+++ b/data/yaml/checks/design/0153.yaml
@@ -1,5 +1,5 @@
 id: '0153'
-severity: '[CRITICAL]'
+severity: critical
 target: design
 platform:
 - mobile

--- a/data/yaml/checks/design/0211.yaml
+++ b/data/yaml/checks/design/0211.yaml
@@ -1,5 +1,5 @@
 id: '0211'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0241.yaml
+++ b/data/yaml/checks/design/0241.yaml
@@ -1,5 +1,5 @@
 id: '0241'
-severity: '[MINOR]'
+severity: minor
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0242.yaml
+++ b/data/yaml/checks/design/0242.yaml
@@ -1,5 +1,5 @@
 id: '0242'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0271.yaml
+++ b/data/yaml/checks/design/0271.yaml
@@ -1,5 +1,5 @@
 id: '0271'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0331.yaml
+++ b/data/yaml/checks/design/0331.yaml
@@ -1,5 +1,5 @@
 id: '0331'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0332.yaml
+++ b/data/yaml/checks/design/0332.yaml
@@ -1,5 +1,5 @@
 id: '0332'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0333.yaml
+++ b/data/yaml/checks/design/0333.yaml
@@ -1,5 +1,5 @@
 id: '0333'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - mobile

--- a/data/yaml/checks/design/0334.yaml
+++ b/data/yaml/checks/design/0334.yaml
@@ -1,5 +1,5 @@
 id: '0334'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - mobile

--- a/data/yaml/checks/design/0361.yaml
+++ b/data/yaml/checks/design/0361.yaml
@@ -1,5 +1,5 @@
 id: '0361'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0362.yaml
+++ b/data/yaml/checks/design/0362.yaml
@@ -1,5 +1,5 @@
 id: '0362'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - mobile

--- a/data/yaml/checks/design/0391.yaml
+++ b/data/yaml/checks/design/0391.yaml
@@ -1,5 +1,5 @@
 id: '0391'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0421.yaml
+++ b/data/yaml/checks/design/0421.yaml
@@ -1,5 +1,5 @@
 id: '0421'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0451.yaml
+++ b/data/yaml/checks/design/0451.yaml
@@ -1,5 +1,5 @@
 id: '0451'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0481.yaml
+++ b/data/yaml/checks/design/0481.yaml
@@ -1,5 +1,5 @@
 id: '0481'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0511.yaml
+++ b/data/yaml/checks/design/0511.yaml
@@ -1,5 +1,5 @@
 id: '0511'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0541.yaml
+++ b/data/yaml/checks/design/0541.yaml
@@ -1,5 +1,5 @@
 id: '0541'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0542.yaml
+++ b/data/yaml/checks/design/0542.yaml
@@ -1,5 +1,5 @@
 id: '0542'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0543.yaml
+++ b/data/yaml/checks/design/0543.yaml
@@ -1,5 +1,5 @@
 id: '0543'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0581.yaml
+++ b/data/yaml/checks/design/0581.yaml
@@ -1,5 +1,5 @@
 id: '0581'
-severity: '[CRITICAL]'
+severity: critical
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0631.yaml
+++ b/data/yaml/checks/design/0631.yaml
@@ -1,5 +1,5 @@
 id: '0631'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0661.yaml
+++ b/data/yaml/checks/design/0661.yaml
@@ -1,5 +1,5 @@
 id: '0661'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0721.yaml
+++ b/data/yaml/checks/design/0721.yaml
@@ -1,5 +1,5 @@
 id: '0721'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0722.yaml
+++ b/data/yaml/checks/design/0722.yaml
@@ -1,5 +1,5 @@
 id: '0722'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - mobile

--- a/data/yaml/checks/design/0751.yaml
+++ b/data/yaml/checks/design/0751.yaml
@@ -1,5 +1,5 @@
 id: '0751'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0781.yaml
+++ b/data/yaml/checks/design/0781.yaml
@@ -1,5 +1,5 @@
 id: '0781'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0811.yaml
+++ b/data/yaml/checks/design/0811.yaml
@@ -1,5 +1,5 @@
 id: '0811'
-severity: '[MINOR]'
+severity: minor
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0841.yaml
+++ b/data/yaml/checks/design/0841.yaml
@@ -1,5 +1,5 @@
 id: '0841'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0931.yaml
+++ b/data/yaml/checks/design/0931.yaml
@@ -1,5 +1,5 @@
 id: '0931'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0961.yaml
+++ b/data/yaml/checks/design/0961.yaml
@@ -1,5 +1,5 @@
 id: '0961'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/0991.yaml
+++ b/data/yaml/checks/design/0991.yaml
@@ -1,5 +1,5 @@
 id: '0991'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1021.yaml
+++ b/data/yaml/checks/design/1021.yaml
@@ -1,5 +1,5 @@
 id: '1021'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1051.yaml
+++ b/data/yaml/checks/design/1051.yaml
@@ -1,5 +1,5 @@
 id: '1051'
-severity: '[CRITICAL]'
+severity: critical
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1081.yaml
+++ b/data/yaml/checks/design/1081.yaml
@@ -1,5 +1,5 @@
 id: '1081'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1111.yaml
+++ b/data/yaml/checks/design/1111.yaml
@@ -1,5 +1,5 @@
 id: '1111'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1141.yaml
+++ b/data/yaml/checks/design/1141.yaml
@@ -1,5 +1,5 @@
 id: '1141'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1171.yaml
+++ b/data/yaml/checks/design/1171.yaml
@@ -1,5 +1,5 @@
 id: '1171'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1201.yaml
+++ b/data/yaml/checks/design/1201.yaml
@@ -1,5 +1,5 @@
 id: '1201'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1231.yaml
+++ b/data/yaml/checks/design/1231.yaml
@@ -1,5 +1,5 @@
 id: '1231'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1261.yaml
+++ b/data/yaml/checks/design/1261.yaml
@@ -1,5 +1,5 @@
 id: '1261'
-severity: '[CRITICAL]'
+severity: critical
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1291.yaml
+++ b/data/yaml/checks/design/1291.yaml
@@ -1,5 +1,5 @@
 id: '1291'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1292.yaml
+++ b/data/yaml/checks/design/1292.yaml
@@ -1,5 +1,5 @@
 id: '1292'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1321.yaml
+++ b/data/yaml/checks/design/1321.yaml
@@ -1,5 +1,5 @@
 id: '1321'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1351.yaml
+++ b/data/yaml/checks/design/1351.yaml
@@ -1,5 +1,5 @@
 id: '1351'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1381.yaml
+++ b/data/yaml/checks/design/1381.yaml
@@ -1,5 +1,5 @@
 id: '1381'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1421.yaml
+++ b/data/yaml/checks/design/1421.yaml
@@ -1,5 +1,5 @@
 id: '1421'
-severity: '[CRITICAL]'
+severity: critical
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1451.yaml
+++ b/data/yaml/checks/design/1451.yaml
@@ -1,5 +1,5 @@
 id: '1451'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1481.yaml
+++ b/data/yaml/checks/design/1481.yaml
@@ -1,5 +1,5 @@
 id: '1481'
-severity: '[MAJOR]'
+severity: major
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1511.yaml
+++ b/data/yaml/checks/design/1511.yaml
@@ -1,5 +1,5 @@
 id: '1511'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1541.yaml
+++ b/data/yaml/checks/design/1541.yaml
@@ -1,5 +1,5 @@
 id: '1541'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1542.yaml
+++ b/data/yaml/checks/design/1542.yaml
@@ -1,5 +1,5 @@
 id: '1542'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1571.yaml
+++ b/data/yaml/checks/design/1571.yaml
@@ -1,5 +1,5 @@
 id: '1571'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1601.yaml
+++ b/data/yaml/checks/design/1601.yaml
@@ -1,5 +1,5 @@
 id: '1601'
-severity: '[MINOR]'
+severity: minor
 target: design
 platform:
 - web

--- a/data/yaml/checks/design/1631.yaml
+++ b/data/yaml/checks/design/1631.yaml
@@ -1,5 +1,5 @@
 id: '1631'
-severity: '[NORMAL]'
+severity: normal
 target: design
 platform:
 - web

--- a/data/yaml/checks/product/0021.yaml
+++ b/data/yaml/checks/product/0021.yaml
@@ -1,5 +1,5 @@
 id: '0021'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0051.yaml
+++ b/data/yaml/checks/product/0051.yaml
@@ -1,5 +1,5 @@
 id: '0051'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0081.yaml
+++ b/data/yaml/checks/product/0081.yaml
@@ -1,5 +1,5 @@
 id: '0081'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0111.yaml
+++ b/data/yaml/checks/product/0111.yaml
@@ -1,5 +1,5 @@
 id: '0111'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0112.yaml
+++ b/data/yaml/checks/product/0112.yaml
@@ -1,5 +1,5 @@
 id: '0112'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0141.yaml
+++ b/data/yaml/checks/product/0141.yaml
@@ -1,5 +1,5 @@
 id: '0141'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0171.yaml
+++ b/data/yaml/checks/product/0171.yaml
@@ -1,5 +1,5 @@
 id: '0171'
-severity: '[CRITICAL]'
+severity: critical
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0172.yaml
+++ b/data/yaml/checks/product/0172.yaml
@@ -1,5 +1,5 @@
 id: '0172'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0201.yaml
+++ b/data/yaml/checks/product/0201.yaml
@@ -1,5 +1,5 @@
 id: '0201'
-severity: '[CRITICAL]'
+severity: critical
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0231.yaml
+++ b/data/yaml/checks/product/0231.yaml
@@ -1,5 +1,5 @@
 id: '0231'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0261.yaml
+++ b/data/yaml/checks/product/0261.yaml
@@ -1,5 +1,5 @@
 id: '0261'
-severity: '[MINOR]'
+severity: minor
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0262.yaml
+++ b/data/yaml/checks/product/0262.yaml
@@ -1,5 +1,5 @@
 id: '0262'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0321.yaml
+++ b/data/yaml/checks/product/0321.yaml
@@ -1,5 +1,5 @@
 id: '0321'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0322.yaml
+++ b/data/yaml/checks/product/0322.yaml
@@ -1,5 +1,5 @@
 id: '0322'
-severity: '[MINOR]'
+severity: minor
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0323.yaml
+++ b/data/yaml/checks/product/0323.yaml
@@ -1,5 +1,5 @@
 id: '0323'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0324.yaml
+++ b/data/yaml/checks/product/0324.yaml
@@ -1,5 +1,5 @@
 id: '0324'
-severity: '[MINOR]'
+severity: minor
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0325.yaml
+++ b/data/yaml/checks/product/0325.yaml
@@ -1,5 +1,5 @@
 id: '0325'
-severity: '[MINOR]'
+severity: minor
 target: product
 platform:
 - mobile

--- a/data/yaml/checks/product/0326.yaml
+++ b/data/yaml/checks/product/0326.yaml
@@ -1,5 +1,5 @@
 id: '0326'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - mobile

--- a/data/yaml/checks/product/0351.yaml
+++ b/data/yaml/checks/product/0351.yaml
@@ -1,5 +1,5 @@
 id: '0351'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0352.yaml
+++ b/data/yaml/checks/product/0352.yaml
@@ -1,5 +1,5 @@
 id: '0352'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0411.yaml
+++ b/data/yaml/checks/product/0411.yaml
@@ -1,5 +1,5 @@
 id: '0411'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0412.yaml
+++ b/data/yaml/checks/product/0412.yaml
@@ -1,5 +1,5 @@
 id: '0412'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0413.yaml
+++ b/data/yaml/checks/product/0413.yaml
@@ -1,5 +1,5 @@
 id: '0413'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0441.yaml
+++ b/data/yaml/checks/product/0441.yaml
@@ -1,5 +1,5 @@
 id: '0441'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0471.yaml
+++ b/data/yaml/checks/product/0471.yaml
@@ -1,5 +1,5 @@
 id: '0471'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0501.yaml
+++ b/data/yaml/checks/product/0501.yaml
@@ -1,5 +1,5 @@
 id: '0501'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0531.yaml
+++ b/data/yaml/checks/product/0531.yaml
@@ -1,5 +1,5 @@
 id: '0531'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0561.yaml
+++ b/data/yaml/checks/product/0561.yaml
@@ -1,5 +1,5 @@
 id: '0561'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0562.yaml
+++ b/data/yaml/checks/product/0562.yaml
@@ -1,5 +1,5 @@
 id: '0562'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0591.yaml
+++ b/data/yaml/checks/product/0591.yaml
@@ -1,5 +1,5 @@
 id: '0591'
-severity: '[CRITICAL]'
+severity: critical
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0592.yaml
+++ b/data/yaml/checks/product/0592.yaml
@@ -1,5 +1,5 @@
 id: '0592'
-severity: '[CRITICAL]'
+severity: critical
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0621.yaml
+++ b/data/yaml/checks/product/0621.yaml
@@ -1,5 +1,5 @@
 id: '0621'
-severity: '[CRITICAL]'
+severity: critical
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0651.yaml
+++ b/data/yaml/checks/product/0651.yaml
@@ -1,5 +1,5 @@
 id: '0651'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0681.yaml
+++ b/data/yaml/checks/product/0681.yaml
@@ -1,5 +1,5 @@
 id: '0681'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0682.yaml
+++ b/data/yaml/checks/product/0682.yaml
@@ -1,5 +1,5 @@
 id: '0682'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0711.yaml
+++ b/data/yaml/checks/product/0711.yaml
@@ -1,5 +1,5 @@
 id: '0711'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0771.yaml
+++ b/data/yaml/checks/product/0771.yaml
@@ -1,5 +1,5 @@
 id: '0771'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0801.yaml
+++ b/data/yaml/checks/product/0801.yaml
@@ -1,5 +1,5 @@
 id: '0801'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0861.yaml
+++ b/data/yaml/checks/product/0861.yaml
@@ -1,5 +1,5 @@
 id: '0861'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0862.yaml
+++ b/data/yaml/checks/product/0862.yaml
@@ -1,5 +1,5 @@
 id: '0862'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0891.yaml
+++ b/data/yaml/checks/product/0891.yaml
@@ -1,5 +1,5 @@
 id: '0891'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0921.yaml
+++ b/data/yaml/checks/product/0921.yaml
@@ -1,5 +1,5 @@
 id: '0921'
-severity: '[MINOR]'
+severity: minor
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0922.yaml
+++ b/data/yaml/checks/product/0922.yaml
@@ -1,5 +1,5 @@
 id: '0922'
-severity: '[MINOR]'
+severity: minor
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/0951.yaml
+++ b/data/yaml/checks/product/0951.yaml
@@ -1,5 +1,5 @@
 id: '0951'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1071.yaml
+++ b/data/yaml/checks/product/1071.yaml
@@ -1,5 +1,5 @@
 id: '1071'
-severity: '[CRITICAL]'
+severity: critical
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1101.yaml
+++ b/data/yaml/checks/product/1101.yaml
@@ -1,5 +1,5 @@
 id: '1101'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1131.yaml
+++ b/data/yaml/checks/product/1131.yaml
@@ -1,5 +1,5 @@
 id: '1131'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1191.yaml
+++ b/data/yaml/checks/product/1191.yaml
@@ -1,5 +1,5 @@
 id: '1191'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1221.yaml
+++ b/data/yaml/checks/product/1221.yaml
@@ -1,5 +1,5 @@
 id: '1221'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1251.yaml
+++ b/data/yaml/checks/product/1251.yaml
@@ -1,5 +1,5 @@
 id: '1251'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1281.yaml
+++ b/data/yaml/checks/product/1281.yaml
@@ -1,5 +1,5 @@
 id: '1281'
-severity: '[CRITICAL]'
+severity: critical
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1311.yaml
+++ b/data/yaml/checks/product/1311.yaml
@@ -1,5 +1,5 @@
 id: '1311'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1312.yaml
+++ b/data/yaml/checks/product/1312.yaml
@@ -1,5 +1,5 @@
 id: '1312'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1313.yaml
+++ b/data/yaml/checks/product/1313.yaml
@@ -1,5 +1,5 @@
 id: '1313'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - mobile

--- a/data/yaml/checks/product/1411.yaml
+++ b/data/yaml/checks/product/1411.yaml
@@ -1,5 +1,5 @@
 id: '1411'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1441.yaml
+++ b/data/yaml/checks/product/1441.yaml
@@ -1,5 +1,5 @@
 id: '1441'
-severity: '[CRITICAL]'
+severity: critical
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1471.yaml
+++ b/data/yaml/checks/product/1471.yaml
@@ -1,5 +1,5 @@
 id: '1471'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1501.yaml
+++ b/data/yaml/checks/product/1501.yaml
@@ -1,5 +1,5 @@
 id: '1501'
-severity: '[MAJOR]'
+severity: major
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1531.yaml
+++ b/data/yaml/checks/product/1531.yaml
@@ -1,5 +1,5 @@
 id: '1531'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1561.yaml
+++ b/data/yaml/checks/product/1561.yaml
@@ -1,5 +1,5 @@
 id: '1561'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1562.yaml
+++ b/data/yaml/checks/product/1562.yaml
@@ -1,5 +1,5 @@
 id: '1562'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1591.yaml
+++ b/data/yaml/checks/product/1591.yaml
@@ -1,5 +1,5 @@
 id: '1591'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1621.yaml
+++ b/data/yaml/checks/product/1621.yaml
@@ -1,5 +1,5 @@
 id: '1621'
-severity: '[MINOR]'
+severity: minor
 target: product
 platform:
 - web

--- a/data/yaml/checks/product/1651.yaml
+++ b/data/yaml/checks/product/1651.yaml
@@ -1,5 +1,5 @@
 id: '1651'
-severity: '[NORMAL]'
+severity: normal
 target: product
 platform:
 - web

--- a/data/yaml/gl/dynamic_content/focus.yaml
+++ b/data/yaml/gl/dynamic_content/focus.yaml
@@ -4,7 +4,7 @@ category: dynamic_content
 title:
   ja: OnFocus/OffFocus時の挙動
   en: OnFocus/OffFocus Behavior
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/dynamic_content/hover-magnify.yaml
+++ b/data/yaml/gl/dynamic_content/hover-magnify.yaml
@@ -3,7 +3,7 @@ sortKey: 2011
 category: dynamic_content
 title:
   ja: ホバーで表示されるコンテンツの拡大
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/dynamic_content/hover.yaml
+++ b/data/yaml/gl/dynamic_content/hover.yaml
@@ -3,7 +3,7 @@ sortKey: 2016
 category: dynamic_content
 title:
   ja: ホバーで表示されるコンテンツの非表示
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/dynamic_content/maintain-dom-tree.yaml
+++ b/data/yaml/gl/dynamic_content/maintain-dom-tree.yaml
@@ -3,7 +3,7 @@ sortKey: 2001
 category: dynamic_content
 title:
   ja: 支援技術への適切な情報提供の維持
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/dynamic_content/no-flashing.yaml
+++ b/data/yaml/gl/dynamic_content/no-flashing.yaml
@@ -3,7 +3,7 @@ sortKey: 2036
 category: dynamic_content
 title:
   ja: 閃光を放つコンテンツ
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/dynamic_content/no-interrupt.yaml
+++ b/data/yaml/gl/dynamic_content/no-interrupt.yaml
@@ -3,7 +3,7 @@ sortKey: 2041
 category: dynamic_content
 title:
   ja: 割り込み表示
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/dynamic_content/pause-movement.yaml
+++ b/data/yaml/gl/dynamic_content/pause-movement.yaml
@@ -3,7 +3,7 @@ sortKey: 2026
 category: dynamic_content
 title:
   ja: 点滅、スクロールを伴うコンテンツ
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/dynamic_content/pause-refresh.yaml
+++ b/data/yaml/gl/dynamic_content/pause-refresh.yaml
@@ -3,7 +3,7 @@ sortKey: 2031
 category: dynamic_content
 title:
   ja: 自動更新されるコンテンツ
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/dynamic_content/status.yaml
+++ b/data/yaml/gl/dynamic_content/status.yaml
@@ -3,7 +3,7 @@ sortKey: 2021
 category: dynamic_content
 title:
   ja: ステータス・メッセージの適切な実装
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/form/color-only.yaml
+++ b/data/yaml/gl/form/color-only.yaml
@@ -3,7 +3,7 @@ sortKey: 1911
 category: form
 title:
   ja: 複数の視覚的要素を用いた表現
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/form/continue.yaml
+++ b/data/yaml/gl/form/continue.yaml
@@ -3,7 +3,7 @@ sortKey: 1926
 category: form
 title:
   ja: 制限時間超過後の操作の継続
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/form/dynamic-content-change.yaml
+++ b/data/yaml/gl/form/dynamic-content-change.yaml
@@ -3,7 +3,7 @@ sortKey: 1941
 category: form
 title:
   ja: フォームの値の変更時の挙動
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/form/dynamic-content-focus.yaml
+++ b/data/yaml/gl/form/dynamic-content-focus.yaml
@@ -3,7 +3,7 @@ sortKey: 1936
 category: form
 title:
   ja: フォーカス時の挙動
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/form/errors-cancel.yaml
+++ b/data/yaml/gl/form/errors-cancel.yaml
@@ -3,7 +3,7 @@ sortKey: 1956
 category: form
 title:
   ja: 誤操作の防止
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/form/errors-correction.yaml
+++ b/data/yaml/gl/form/errors-correction.yaml
@@ -3,7 +3,7 @@ sortKey: 1951
 category: form
 title:
   ja: エラーの修正方法の提示
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/form/errors-identify.yaml
+++ b/data/yaml/gl/form/errors-identify.yaml
@@ -3,7 +3,7 @@ sortKey: 1946
 category: form
 title:
   ja: テキスト情報によるエラーの特定
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/form/hidden-label.yaml
+++ b/data/yaml/gl/form/hidden-label.yaml
@@ -3,7 +3,7 @@ sortKey: 1906
 category: form
 title:
   ja: 表示されているテキストをラベルにできない場合
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/form/label.yaml
+++ b/data/yaml/gl/form/label.yaml
@@ -3,7 +3,7 @@ sortKey: 1901
 category: form
 title:
   ja: 表示されているテキストをラベルとして用いる
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/form/no-timing.yaml
+++ b/data/yaml/gl/form/no-timing.yaml
@@ -3,7 +3,7 @@ sortKey: 1921
 category: form
 title:
   ja: 制限時間を設けない
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/form/tab-order.yaml
+++ b/data/yaml/gl/form/tab-order.yaml
@@ -3,7 +3,7 @@ sortKey: 1931
 category: form
 title:
   ja: 適切なフォーカス順序
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/form/target-size-mobile.yaml
+++ b/data/yaml/gl/form/target-size-mobile.yaml
@@ -3,7 +3,7 @@ sortKey: 1966
 category: form
 title:
   ja: 十分な大きさのクリック/タッチのターゲット（モバイル）
-priority: '[SHOULD]'
+priority: should
 platform:
 - mobile
 guideline: |-

--- a/data/yaml/gl/form/target-size.yaml
+++ b/data/yaml/gl/form/target-size.yaml
@@ -3,7 +3,7 @@ sortKey: 1961
 category: form
 title:
   ja: 十分な大きさのクリック/タッチのターゲット
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/form/timing.yaml
+++ b/data/yaml/gl/form/timing.yaml
@@ -3,7 +3,7 @@ sortKey: 1916
 category: form
 title:
   ja: フォームの入力に制限時間を設ける場合
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/icon/color-only.yaml
+++ b/data/yaml/gl/icon/color-only.yaml
@@ -3,7 +3,7 @@ sortKey: 1706
 category: icon
 title:
   ja: 複数の視覚的要素を用いた表現
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/icon/consistent.yaml
+++ b/data/yaml/gl/icon/consistent.yaml
@@ -3,7 +3,7 @@ sortKey: 1711
 category: icon
 title:
   ja: アイコンの一貫性
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/icon/contrast.yaml
+++ b/data/yaml/gl/icon/contrast.yaml
@@ -3,7 +3,7 @@ sortKey: 1716
 category: icon
 title:
   ja: コントラスト比の確保
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/icon/target-size-mobile.yaml
+++ b/data/yaml/gl/icon/target-size-mobile.yaml
@@ -3,7 +3,7 @@ sortKey: 1726
 category: icon
 title:
   ja: 十分な大きさのクリック/タッチのターゲット（モバイル）
-priority: '[SHOULD]'
+priority: should
 platform:
 - mobile
 guideline: |-

--- a/data/yaml/gl/icon/target-size.yaml
+++ b/data/yaml/gl/icon/target-size.yaml
@@ -3,7 +3,7 @@ sortKey: 1721
 category: icon
 title:
   ja: 十分な大きさのクリック/タッチのターゲット
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/icon/visible-label.yaml
+++ b/data/yaml/gl/icon/visible-label.yaml
@@ -3,7 +3,7 @@ sortKey: 1701
 category: icon
 title:
   ja: テキスト情報の付与
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/image/adjacent-contrast.yaml
+++ b/data/yaml/gl/image/adjacent-contrast.yaml
@@ -3,7 +3,7 @@ sortKey: 1616
 category: image
 title:
   ja: 隣接領域とのコントラスト比の確保
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/image/color-only.yaml
+++ b/data/yaml/gl/image/color-only.yaml
@@ -3,7 +3,7 @@ sortKey: 1611
 category: image
 title:
   ja: 複数の視覚的要素を用いた表現
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/image/decorative.yaml
+++ b/data/yaml/gl/image/decorative.yaml
@@ -3,7 +3,7 @@ sortKey: 1606
 category: image
 title:
   ja: 装飾目的の画像の無視
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/image/description.yaml
+++ b/data/yaml/gl/image/description.yaml
@@ -3,7 +3,7 @@ sortKey: 1601
 category: image
 title:
   ja: 画像の説明の提供
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/image/mobile-text-contrast.yaml
+++ b/data/yaml/gl/image/mobile-text-contrast.yaml
@@ -3,7 +3,7 @@ sortKey: 1626
 category: image
 title:
   ja: モバイルOSでの画像内のテキストのコントラスト比
-priority: '[MUST]'
+priority: must
 platform:
 - mobile
 guideline: |-

--- a/data/yaml/gl/image/text-contrast.yaml
+++ b/data/yaml/gl/image/text-contrast.yaml
@@ -3,7 +3,7 @@ sortKey: 1621
 category: image
 title:
   ja: 画像内のテキストのコントラスト比
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/images_of_text/avoid-usage.yaml
+++ b/data/yaml/gl/images_of_text/avoid-usage.yaml
@@ -3,7 +3,7 @@ sortKey: 1501
 category: images_of_text
 title:
   ja: 画像化されたテキストを使用しない
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/images_of_text/mobile-text-contrast.yaml
+++ b/data/yaml/gl/images_of_text/mobile-text-contrast.yaml
@@ -3,7 +3,7 @@ sortKey: 1516
 category: images_of_text
 title:
   ja: モバイルOSでの画像内のテキストのコントラスト比
-priority: '[MUST]'
+priority: must
 platform:
 - mobile
 guideline: |-

--- a/data/yaml/gl/images_of_text/provide-text.yaml
+++ b/data/yaml/gl/images_of_text/provide-text.yaml
@@ -3,7 +3,7 @@ sortKey: 1506
 category: images_of_text
 title:
   ja: テキスト情報の提供
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/images_of_text/text-contrast.yaml
+++ b/data/yaml/gl/images_of_text/text-contrast.yaml
@@ -3,7 +3,7 @@ sortKey: 1511
 category: images_of_text
 title:
   ja: 画像内のテキストのコントラスト比
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/input_device/focus-indicator.yaml
+++ b/data/yaml/gl/input_device/focus-indicator.yaml
@@ -3,7 +3,7 @@ sortKey: 1316
 category: input_device
 title:
   ja: フォーカス箇所の可視化
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/input_device/focus.yaml
+++ b/data/yaml/gl/input_device/focus.yaml
@@ -3,7 +3,7 @@ sortKey: 1311
 category: input_device
 title:
   ja: 適切なフォーカス順序
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/input_device/independent.yaml
+++ b/data/yaml/gl/input_device/independent.yaml
@@ -3,7 +3,7 @@ sortKey: 1331
 category: input_device
 title:
   ja: 特定の入力ディバイスを前提としない
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/input_device/keyboard-operable.yaml
+++ b/data/yaml/gl/input_device/keyboard-operable.yaml
@@ -3,7 +3,7 @@ sortKey: 1301
 category: input_device
 title:
   ja: キーボード操作を可能にする
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/input_device/no-trap.yaml
+++ b/data/yaml/gl/input_device/no-trap.yaml
@@ -3,7 +3,7 @@ sortKey: 1321
 category: input_device
 title:
   ja: キーボード・トラップの回避
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/input_device/shortcut-keys.yaml
+++ b/data/yaml/gl/input_device/shortcut-keys.yaml
@@ -3,7 +3,7 @@ sortKey: 1336
 category: input_device
 title:
   ja: ショートカット・キーを提供する場合
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/input_device/support-mobile-assistive-tech.yaml
+++ b/data/yaml/gl/input_device/support-mobile-assistive-tech.yaml
@@ -3,7 +3,7 @@ sortKey: 1306
 category: input_device
 title:
   ja: モバイルの支援技術のサポート
-priority: '[MUST]'
+priority: must
 platform:
 - mobile
 guideline: |-

--- a/data/yaml/gl/input_device/use-up-event.yaml
+++ b/data/yaml/gl/input_device/use-up-event.yaml
@@ -3,7 +3,7 @@ sortKey: 1326
 category: input_device
 title:
   ja: ダウン・イベントをトリガーにしない
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/link/color-only.yaml
+++ b/data/yaml/gl/link/color-only.yaml
@@ -3,7 +3,7 @@ sortKey: 1801
 category: link
 title:
   ja: 複数の視覚的要素を用いた表現
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/link/consistent-text.yaml
+++ b/data/yaml/gl/link/consistent-text.yaml
@@ -3,7 +3,7 @@ sortKey: 1811
 category: link
 title:
   ja: 一貫したリンク・テキスト
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/link/tab-order.yaml
+++ b/data/yaml/gl/link/tab-order.yaml
@@ -3,7 +3,7 @@ sortKey: 1816
 category: link
 title:
   ja: 適切なフォーカス順序
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/link/text.yaml
+++ b/data/yaml/gl/link/text.yaml
@@ -3,7 +3,7 @@ sortKey: 1806
 category: link
 title:
   ja: 適切なリンク・テキスト
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/login_session/continue.yaml
+++ b/data/yaml/gl/login_session/continue.yaml
@@ -3,7 +3,7 @@ sortKey: 1211
 category: login_session
 title:
   ja: 制限時間超過後の操作の継続
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/login_session/no-timing.yaml
+++ b/data/yaml/gl/login_session/no-timing.yaml
@@ -3,7 +3,7 @@ sortKey: 1206
 category: login_session
 title:
   ja: 制限時間を設けない
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/login_session/timing.yaml
+++ b/data/yaml/gl/login_session/timing.yaml
@@ -3,7 +3,7 @@ sortKey: 1201
 category: login_session
 title:
   ja: ログイン・セッションにタイムアウトを設ける場合
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/markup/component-implementation.yaml
+++ b/data/yaml/gl/markup/component-implementation.yaml
@@ -3,7 +3,7 @@ sortKey: 1011
 category: markup
 title:
   ja: 対話的なUIコンポーネントの実装
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/markup/component.yaml
+++ b/data/yaml/gl/markup/component.yaml
@@ -3,7 +3,7 @@ sortKey: 1016
 category: markup
 title:
   ja: コンポーネントをアクセシブルにする
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/markup/semantics.yaml
+++ b/data/yaml/gl/markup/semantics.yaml
@@ -3,7 +3,7 @@ sortKey: 1001
 category: markup
 title:
   ja: 文書構造を適切に示すマークアップ、実装を行う
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/markup/valid.yaml
+++ b/data/yaml/gl/markup/valid.yaml
@@ -3,7 +3,7 @@ sortKey: 1006
 category: markup
 title:
   ja: 文法的に正しいマークアップ
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/multimedia/background-sound.yaml
+++ b/data/yaml/gl/multimedia/background-sound.yaml
@@ -3,7 +3,7 @@ sortKey: 2151
 category: multimedia
 title:
   ja: 充分に小さい背景音
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/multimedia/caption.yaml
+++ b/data/yaml/gl/multimedia/caption.yaml
@@ -3,7 +3,7 @@ sortKey: 2126
 category: multimedia
 title:
   ja: キャプションの提供
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/multimedia/no-trap.yaml
+++ b/data/yaml/gl/multimedia/no-trap.yaml
@@ -3,7 +3,7 @@ sortKey: 2116
 category: multimedia
 title:
   ja: キーボード・トラップの回避
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/multimedia/operable.yaml
+++ b/data/yaml/gl/multimedia/operable.yaml
@@ -3,7 +3,7 @@ sortKey: 2106
 category: multimedia
 title:
   ja: 音声の自動再生
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/multimedia/pause-movement.yaml
+++ b/data/yaml/gl/multimedia/pause-movement.yaml
@@ -3,7 +3,7 @@ sortKey: 2111
 category: multimedia
 title:
   ja: 動きを伴うコンテンツ
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/multimedia/perceivable.yaml
+++ b/data/yaml/gl/multimedia/perceivable.yaml
@@ -3,7 +3,7 @@ sortKey: 2101
 category: multimedia
 title:
   ja: 音声・映像コンテンツの存在を明示する
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/multimedia/sign-language.yaml
+++ b/data/yaml/gl/multimedia/sign-language.yaml
@@ -3,7 +3,7 @@ sortKey: 2146
 category: multimedia
 title:
   ja: 手話の提供
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/multimedia/text-alternative.yaml
+++ b/data/yaml/gl/multimedia/text-alternative.yaml
@@ -3,7 +3,7 @@ sortKey: 2121
 category: multimedia
 title:
   ja: テキスト情報と同等の内容にする
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/multimedia/transcript.yaml
+++ b/data/yaml/gl/multimedia/transcript.yaml
@@ -3,7 +3,7 @@ sortKey: 2131
 category: multimedia
 title:
   ja: 書き起こしテキストの提供
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/multimedia/video-description-no-exception.yaml
+++ b/data/yaml/gl/multimedia/video-description-no-exception.yaml
@@ -3,7 +3,7 @@ sortKey: 2141
 category: multimedia
 title:
   ja: 音声解説の提供
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/multimedia/video-description.yaml
+++ b/data/yaml/gl/multimedia/video-description.yaml
@@ -3,7 +3,7 @@ sortKey: 2136
 category: multimedia
 title:
   ja: テキスト情報または音声解説の提供
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/page/consistent-navigation.yaml
+++ b/data/yaml/gl/page/consistent-navigation.yaml
@@ -3,7 +3,7 @@ sortKey: 1131
 category: page
 title:
   ja: コンポーネントの一貫した出現順序
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/page/headings.yaml
+++ b/data/yaml/gl/page/headings.yaml
@@ -3,7 +3,7 @@ sortKey: 1121
 category: page
 title:
   ja: 適切なセクション分けと見出しの付与
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/page/landmark.yaml
+++ b/data/yaml/gl/page/landmark.yaml
@@ -3,7 +3,7 @@ sortKey: 1106
 category: page
 title:
   ja: ページを構成する領域の明示
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/page/location.yaml
+++ b/data/yaml/gl/page/location.yaml
@@ -3,7 +3,7 @@ sortKey: 1141
 category: page
 title:
   ja: 現在地の明示
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/page/markup-main.yaml
+++ b/data/yaml/gl/page/markup-main.yaml
@@ -3,7 +3,7 @@ sortKey: 1111
 category: page
 title:
   ja: 本文の開始位置の明示
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/page/markup-order.yaml
+++ b/data/yaml/gl/page/markup-order.yaml
@@ -3,7 +3,7 @@ sortKey: 1116
 category: page
 title:
   ja: 適切な記述順序
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/page/orientation.yaml
+++ b/data/yaml/gl/page/orientation.yaml
@@ -3,7 +3,7 @@ sortKey: 1126
 category: page
 title:
   ja: 画面方向を固定しない
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/page/redundant-navigation.yaml
+++ b/data/yaml/gl/page/redundant-navigation.yaml
@@ -3,7 +3,7 @@ sortKey: 1136
 category: page
 title:
   ja: 複数の到達手段
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/page/title.yaml
+++ b/data/yaml/gl/page/title.yaml
@@ -3,7 +3,7 @@ sortKey: 1101
 category: page
 title:
   ja: タイトルの指定
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/text/color-only.yaml
+++ b/data/yaml/gl/text/color-only.yaml
@@ -3,7 +3,7 @@ sortKey: 1406
 category: text
 title:
   ja: 複数の視覚的要素を用いた表現
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/text/component-lang.yaml
+++ b/data/yaml/gl/text/component-lang.yaml
@@ -3,7 +3,7 @@ sortKey: 1426
 category: text
 title:
   ja: テキストを表示するUIコンポーネントの言語の明示
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 - mobile

--- a/data/yaml/gl/text/contrast.yaml
+++ b/data/yaml/gl/text/contrast.yaml
@@ -3,7 +3,7 @@ sortKey: 1461
 category: text
 title:
   ja: コントラスト比の確保
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/text/customize.yaml
+++ b/data/yaml/gl/text/customize.yaml
@@ -3,7 +3,7 @@ sortKey: 1456
 category: text
 title:
   ja: テキスト表示のカスタマイズ
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/text/enable-enlarge.yaml
+++ b/data/yaml/gl/text/enable-enlarge.yaml
@@ -3,7 +3,7 @@ sortKey: 1446
 category: text
 title:
   ja: 文字サイズの設定による200パーセントの拡大表示
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/text/enlarge-settings.yaml
+++ b/data/yaml/gl/text/enlarge-settings.yaml
@@ -3,7 +3,7 @@ sortKey: 1436
 category: text
 title:
   ja: 文字サイズ設定の変更
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/text/heading-label.yaml
+++ b/data/yaml/gl/text/heading-label.yaml
@@ -3,7 +3,7 @@ sortKey: 1411
 category: text
 title:
   ja: 適切な文言の見出し
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/text/mobile-contrast.yaml
+++ b/data/yaml/gl/text/mobile-contrast.yaml
@@ -3,7 +3,7 @@ sortKey: 1466
 category: text
 title:
   ja: モバイルOSでのコントラスト比の確保
-priority: '[MUST]'
+priority: must
 platform:
 - mobile
 guideline: |-

--- a/data/yaml/gl/text/mobile-enlarge-settings.yaml
+++ b/data/yaml/gl/text/mobile-enlarge-settings.yaml
@@ -3,7 +3,7 @@ sortKey: 1441
 category: text
 title:
   ja: モバイルOSの文字サイズ設定の変更
-priority: '[MUST]'
+priority: must
 platform:
 - mobile
 guideline: |-

--- a/data/yaml/gl/text/multiple-modality.yaml
+++ b/data/yaml/gl/text/multiple-modality.yaml
@@ -3,7 +3,7 @@ sortKey: 1401
 category: text
 title:
   ja: 特定の感覚に依存しない表現
-priority: '[MUST]'
+priority: must
 platform:
 - web
 - mobile

--- a/data/yaml/gl/text/page-lang.yaml
+++ b/data/yaml/gl/text/page-lang.yaml
@@ -3,7 +3,7 @@ sortKey: 1416
 category: text
 title:
   ja: ページの主たる言語の指定
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/text/phrase-lang.yaml
+++ b/data/yaml/gl/text/phrase-lang.yaml
@@ -3,7 +3,7 @@ sortKey: 1421
 category: text
 title:
   ja: 部分的に使用される言語の明示
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/text/zoom-reflow.yaml
+++ b/data/yaml/gl/text/zoom-reflow.yaml
@@ -3,7 +3,7 @@ sortKey: 1451
 category: text
 title:
   ja: ズーム機能を用いた400パーセントの拡大表示
-priority: '[SHOULD]'
+priority: should
 platform:
 - web
 guideline: |-

--- a/data/yaml/gl/text/zoom.yaml
+++ b/data/yaml/gl/text/zoom.yaml
@@ -3,7 +3,7 @@ sortKey: 1431
 category: text
 title:
   ja: ズーム機能を用いた200パーセントの拡大表示
-priority: '[MUST]'
+priority: must
 platform:
 - web
 guideline: |-

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -158,6 +158,7 @@ def main():
     gl_categories = {}
     for gl in guidelines:
         gl_categories[gl['id']] = category_names[gl['category']][LANG]
+        gl['priority'] = f"[{gl['priority'].upper()}]"
         for sc in gl['sc']:
             wcag_sc[sc]['gls'].append(gl['id'])
 
@@ -170,6 +171,7 @@ def main():
         if f'data/yaml/checks/{check["target"]}/{check["id"]}.yaml' != check['src_path']:
             raise Exception(f'The file path does not match the ID and/or the target in {check["src_path"]}')
 
+        check['severity'] = f"[{check['severity'].upper()}]"
         check['gl_ref'] = []
         check['info'] = []
         for gl in guidelines:


### PR DESCRIPTION
- YAML中のガイドラインの優先度やチェック内容の重篤度の記述について、　'[XXX]' という形式から単に　xxx という形式で良いように修正
- yaml2rst.py: 優先度と重篤度の記述記述形式の変更に暫定的に対応
- ガイドラインの優先度とチェック内容の重篤度の記述を新形式に変更
