### PR TITLE
ガイドライン項目の本文と意図を英訳

### DIFF
--- a/data/json/schemas/guideline.json
+++ b/data/json/schemas/guideline.json
@@ -50,7 +50,7 @@
     },
     "guideline": {
       "description": "main text of the guideline",
-      "type": "string"
+      "$ref": "common.json#/definitions/i18nString"
     },
     "sc": {
       "description": "WCAG SC the guideline corresponds to",
@@ -63,7 +63,7 @@
     },
     "intent": {
       "description": "who benefits and how from the guideline",
-      "type": "string"
+      "$ref": "common.json#/definitions/i18nString"
     },
     "checks": {
       "description": "IDs of the checks for conformance to the guideline",

--- a/data/yaml/gl/dynamic_content/focus.yaml
+++ b/data/yaml/gl/dynamic_content/focus.yaml
@@ -7,16 +7,26 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  OnFocus, OffFocusが以下のような変化を発生させないようにする。
-  
-  -  ページ遷移
-  -  フォーム送信
-  -  モーダル・ダイアログの表示
+guideline:
+  ja: |-
+    OnFocus, OffFocusが以下のような変化を発生させないようにする。
+    
+    -  ページ遷移
+    -  フォーム送信
+    -  モーダル・ダイアログの表示
+  en: |- 
+    OnFocus and OffFocus events should not cause changes like the following:
+    
+    -  Page transition
+    -  Form submission
+    -  Display of modal dialog
 sc:
 - 3.2.1
-intent: |-
-  視覚障害、認知障害があるユーザーが予期できない挙動を発生させない。
+intent:
+  ja: |-
+    視覚障害、認知障害があるユーザーにとって予期できない挙動を発生させない。
+  en: |-
+    Do not cause unexpected behavior for users with visual or cognitive impairments.
 checks:
 - '0152'
 - '0171'

--- a/data/yaml/gl/dynamic_content/hover-magnify.yaml
+++ b/data/yaml/gl/dynamic_content/hover-magnify.yaml
@@ -6,12 +6,18 @@ title:
   en: Magnification of the Content Displayed by Mouseover (Hover)
 platform:
 - web
-guideline: |-
-  マウスオーバー（ホバー）で表示されるコンテンツについて、ポインターをマウスオーバーで表示されたコンテンツ上に移動しても、コンテンツが消えないようにすることで、そのコンテンツを拡大表示して利用することを可能にする。
+guideline:
+  ja: |-
+    マウスオーバー（ホバー）で表示されるコンテンツについて、マウスオーバーで表示されたコンテンツ上にポインターを移動しても、コンテンツが消えないようにすることで、そのコンテンツを拡大表示して利用することを可能にする。
+  en: |-
+    Regarding content displayed on mouseover (hover), ensure that the content does not disappear when the pointer is moved over the mouseover-displayed content, to allow for the use of that content with magnification.
 sc:
 - 1.4.13
-intent: |-
-  拡大表示を利用しているロービジョン者が、マウスオーバーで表示される内容を利用できるようにする。
+intent:
+  ja: |-
+    拡大表示を利用しているロービジョン者が、マウスオーバーで表示される内容を利用できるようにする。
+  en: |-
+    Allow users with low vision who use magnification to use the content displayed by mouseover.
 checks:
 - '0092'
 - '0112'

--- a/data/yaml/gl/dynamic_content/hover.yaml
+++ b/data/yaml/gl/dynamic_content/hover.yaml
@@ -6,15 +6,24 @@ title:
   en: Hiding the Content Displayed by Mouseover (Hover)
 platform:
 - web
-guideline: |-
-  マウスオーバー（ホバー）で表示されるコンテンツについて、以下のすべてを満たす。
-  
-  -  ポインターを移動させることなく、マウスオーバーで表示されたコンテンツを非表示にできる。（Escキーで消える、など）
-  -  マウスオーバー状態ではなくなった場合、ユーザーが非表示にする操作を行った場合、内容が無効になった場合にのみ、マウスオーバーで表示されたコンテンツを非表示にする。
+guideline:
+  ja: |-
+    マウスオーバー（ホバー）で表示されるコンテンツについて、以下のすべてを満たす。
+    
+    -  ポインターを移動させることなく、マウスオーバーで表示されたコンテンツを非表示にできる。（Escキーで消える、など）
+    -  マウスオーバー状態ではなくなった場合、ユーザーが非表示にする操作を行った場合、内容が無効になった場合にのみ、マウスオーバーで表示されたコンテンツを非表示にする。
+  en: |-
+    Regarding content displayed on mouseover (hover), ensure that all of the following are satisfied:
+    
+    -  The mouseover-displayed content can be hidden without moving the pointer. (For example, it disappears when the Esc key is pressed.)
+    -  The mouseover-displayed content is hidden only when the mouseover state is no longer present, the user performs an operation to hide it, or the content becomes invalid.
 sc:
 - 1.4.13
-intent: |-
-  拡大表示を利用しているロービジョン者が、マウスオーバーで表示される内容を利用できるようにする。
+intent:
+  ja: |-
+    拡大表示を利用しているロービジョン者が、マウスオーバーで表示される内容を利用できるようにする。
+  en: |-
+    Allow users with low vision who use magnification to use the content displayed by mouseover.
 checks:
 - '0091'
 - '0111'

--- a/data/yaml/gl/dynamic_content/maintain-dom-tree.yaml
+++ b/data/yaml/gl/dynamic_content/maintain-dom-tree.yaml
@@ -7,19 +7,31 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  ユーザーの操作によってコンテンツが増減するようなページでは、どの状態においてもスクリーン・リーダーが適切に情報を取得できる状態を維持する。
+guideline:
+  ja: |-
+    ユーザーの操作によってコンテンツが増減するようなページでは、ページがどの状態にあってもスクリーン・リーダーが適切に情報を取得できる状態を維持する。
 
-  *  スクリーン・リーダーで最初から読み進めた場合に、コンテンツの意味が正しく伝わるコンテンツの順序
-  *  視覚的に提供されている情報と過不足のない情報が支援技術に伝わる状態
+    *  スクリーン・リーダーで最初から読み進めた場合に、コンテンツの意味が正しく伝わるコンテンツの順序
+    *  視覚的に提供されている情報と過不足のない情報が支援技術に伝わる状態
+  en: |-
+    In pages where content increases or decreases upon user actions, maintain a state in which screen readers can appropriately acquire information, regardless of the page's state.
+
+    *  The order of content that conveys the correct meaning of the content when read from the beginning by a screen reader.
+    *  A state where information provided visually is conveyed accurately and without omission to assistive technologies.
 sc:
 - 1.3.1
 - 1.3.2
-intent: |-
-  スクリーン・リーダーなどの支援技術のユーザーが、コンテンツを正しく理解できるようにする。
+intent:
+  ja: |-
+    スクリーン・リーダーなどの支援技術のユーザーが、コンテンツを正しく理解できるようにする。
 
-  -  Webの場合、動的に追加されるコンテンツが、DOMツリーの適切な位置に挿入されることで、スクリーン・リーダーのユーザーがそのコンテンツの存在を認知し、内容を理解することができる。
-  -  モーダル・ダイアログ、開閉するメニュー、アコーディオンなどで注意が必要。
+    -  Webの場合、動的に追加されるコンテンツが、DOMツリーの適切な位置に挿入されることで、スクリーン・リーダーのユーザーがそのコンテンツの存在を認知し、内容を理解することができる。
+    -  モーダル・ダイアログ、開閉するメニュー、アコーディオンなどで注意が必要。
+  en: |-
+    Ensure that users of assistive technologies such as screen readers can correctly understand the content.
+
+    -  In the case of Web content, dynamically added content is inserted at the appropriate position in the DOM tree, so that users of screen readers can recognize the existence of the content and understand its content.
+    -  Special attention is needed for modal dialogs, expandable/collapsible menus, accordions, and similar elements.
 checks:
 - '0711'
 - '1313'

--- a/data/yaml/gl/dynamic_content/no-flashing.yaml
+++ b/data/yaml/gl/dynamic_content/no-flashing.yaml
@@ -7,13 +7,19 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  どの1秒間においても3回を超える閃光を放つものがないようにする。
+guideline:
+  ja: |-
+    どの1秒間においても3回を超える閃光を放つものがないようにする。
+  en: |-
+    Ensure that there are no elements emitting flashes more than three times in any one-second period.
 sc:
 - 2.3.1
 - 2.3.2
-intent: |-
-  光感受性の発作を防ぐ。
+intent:
+  ja: |-
+    光感受性の発作を防ぐ。
+  en: |-
+    Prevent photosensitive seizures.
 checks:
 - '1261'
 - '1281'

--- a/data/yaml/gl/dynamic_content/no-interrupt.yaml
+++ b/data/yaml/gl/dynamic_content/no-interrupt.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  緊急性が高い情報を提示する場合を除いて、プッシュ通知や自動更新などによる割り込みを発生させない。
+guideline:
+  ja: |-
+    緊急性が高い情報を提示する場合を除いて、プッシュ通知や自動更新などによる割り込みを発生させない。
+  en: |-
+    Except when presenting highly urgent information, avoid causing interruptions through push notifications or automatic updates.
 sc:
 - 2.2.4
-intent: |-
-  ロービジョン者や認知障害者が、集中を阻害されないようにする。
+intent:
+  ja: |-
+    ロービジョン者や認知障害者が、集中を阻害されないようにする。
+  en: |-
+    Ensure that people with low vision or cognitive impairments are not distracted.
 checks:
 - '1291'
 - '1292'

--- a/data/yaml/gl/dynamic_content/pause-movement.yaml
+++ b/data/yaml/gl/dynamic_content/pause-movement.yaml
@@ -9,11 +9,18 @@ platform:
 - mobile
 sc:
 - 2.2.2
-guideline: |-
-  同じページ上に、自動的に開始し5秒以上継続する、点滅や自動スクロールを伴うコンテンツと、他のコンテンツを一緒に配置しない。
-  そのようなコンテンツを作る場合は、ユーザーが一時停止、停止、または非表示にすることができるようにする。
-intent: |-
-  ロービジョン者や認知障害者が、集中を阻害されないようにする。
+guideline:
+  ja: |-
+    同じページ上に、自動的に開始し5秒以上継続する、点滅や自動スクロールを伴うコンテンツと、他のコンテンツを一緒に配置しない。
+    そのようなコンテンツを作る場合は、ユーザーが一時停止、停止、または非表示にすることができるようにする。
+  en: |-
+    Do not place content that blinks for more than five seconds or scrolls automatically on the same page as other content.
+    If you create such content, ensure that users can pause, stop, or hide it.  
+intent:
+  ja: |-
+    ロービジョン者や認知障害者が、集中を阻害されないようにする。
+  en: |-
+    Ensure that people with low vision or cognitive impairments are not distracted.
 checks:
 - '1201'
 - '1221'

--- a/data/yaml/gl/dynamic_content/pause-refresh.yaml
+++ b/data/yaml/gl/dynamic_content/pause-refresh.yaml
@@ -7,13 +7,20 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  予め設定された間隔で自動的に内容が更新されたり非表示になったりするコンテンツを作らない。
-  そのようなコンテンツを作る場合は、ユーザーが一時停止、停止、非表示にすることができるか、更新頻度を調整できるようにする。
+guideline:
+  ja: |-
+    予め設定された間隔で自動的に内容が更新されたり非表示になったりするコンテンツを作らない。
+    そのようなコンテンツを作る場合は、ユーザーが一時停止、停止、非表示にすることができるか、更新頻度を調整できるようにする。
+  en: |-
+    Do not create content that is automatically updated or hidden at preset intervals.
+    If you create such content, ensure that users can pause, stop, or hide it, or adjust the update frequency.
 sc:
 - 2.2.2
-intent: |-
-  ロービジョン者や認知障害者が、集中を阻害されないようにする。
+intent:
+  ja: |-
+    ロービジョン者や認知障害者が、集中を阻害されないようにする。
+  en: |-
+    Ensure that people with low vision or cognitive impairments are not distracted.
 checks:
 - '1231'
 - '1251'

--- a/data/yaml/gl/dynamic_content/status.yaml
+++ b/data/yaml/gl/dynamic_content/status.yaml
@@ -7,15 +7,24 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  ステータス・メッセージについて、以下のすべてを満たす。
-  
-  -  スクリーン・リーダーに自動的に読み上げられるようにする。
-  -  ステータス・メッセージであることやその内容が、 ``role`` やその他のプロパティーを通して分かるようにする。
+guideline:
+  ja: |-
+    ステータス・メッセージについて、以下のすべてを満たす。
+    
+    -  スクリーン・リーダーに自動的に読み上げられるようにする。
+    -  ステータス・メッセージであることやその内容が、 ``role`` やその他のプロパティーを通して分かるようにする。
+  en: |-
+    Ensure that status messages meet all of the following criteria:
+    
+    -  They are read out automatically by a screen reader.
+    -  They are recognized as status messages and their content is understood through the ``role`` and other properties.
 sc:
 - 4.1.3
-intent: |-
-  視覚障害者が、ステータス・メッセージを遅滞なく確認できるようにする。
+intent:
+  ja: |-
+    視覚障害者が、ステータス・メッセージを遅滞なく確認できるようにする。
+  en: |-
+    Ensure that people with visual impairments can check status messages without delay.
 checks:
 - '1171'
 - '1181'

--- a/data/yaml/gl/form/color-only.yaml
+++ b/data/yaml/gl/form/color-only.yaml
@@ -7,13 +7,19 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  必須項目やエラー表示に際して、色に加えて他の視覚的要素も用いる。
+guideline:
+  ja: |-
+    必須項目やエラー表示に際して、色に加えて他の視覚的要素も用いる。
+  en: |-
+    When indicating required fields or displaying errors, use visual elements in addition to color.
 sc:
 - 1.3.3
 - 1.4.1
-intent: |-
-  視覚障害者や色弱者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    視覚障害者や色弱者が、コンテンツを利用できるようにする。
+  en: |-
+    Ensure that people with visual impairments or color vision deficiencies can use the content.
 checks:
 - '0031'
 - '0051'

--- a/data/yaml/gl/form/continue.yaml
+++ b/data/yaml/gl/form/continue.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  制限時間を超過した場合も、データを失うことなくユーザーが操作を継続できるようにする。
+guideline:
+  ja: |-
+    制限時間を超過した場合も、データを失うことなくユーザーが操作を継続できるようにする。
+  en: |-
+    Ensure that users can continue their operation without losing data even after exceeding the time limit.
 sc:
 - 2.2.5
-intent: |-
-  コンテンツの読み取りや理解に時間がかかる場合や、入力操作などに時間がかかる場合にも問題なくフォームを利用できるようにする。
+intent:
+  ja: |-
+    コンテンツの読み取りや理解に時間がかかる場合や、入力操作などに時間がかかる場合にも問題なくフォームを利用できるようにする。
+  en: |-
+    Ensure that forms can be used without issue even when it takes time to read or understand the content, or when input operations take time.
 checks:
 - '1021'
 info:

--- a/data/yaml/gl/form/dynamic-content-change.yaml
+++ b/data/yaml/gl/form/dynamic-content-change.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  値が変更されたときに、コンテンツの意味の変更、ページ全体に及ぶような変化、他のフォーム・フィールドの値の変更などを引き起こすようなフォーム・フィールドを作らない、またはそのようなフォーム・フィールドの挙動について、事前にユーザーに知らせる。
+guideline:
+  ja: |-
+    値が変更されたときに、コンテンツの意味の変更、ページ全体に及ぶような変化、他のフォーム・フィールドの値の変更などを引き起こすようなフォーム・フィールドを作らない、またはそのようなフォーム・フィールドの挙動について、事前にユーザーに知らせる。
+  en: |-
+    Do not create form fields that, when their values are changed, lead to changes in the meaning of the content, significant alterations across the entire page, or changes in the values of other form fields. Alternatively, inform users in advance about the behavior of such form fields.
 sc:
 - 3.2.2
-intent: |-
-  視覚障害、認知障害があるユーザーが予期できない挙動を発生させない。
+intent:
+  ja: |-
+    視覚障害、認知障害があるユーザーが予期できない挙動を発生させない。
+  en: |-
+    Do not cause behaviors that are unexpected for users with visual or cognitive impairments.
 checks:
 - '1051'
 - '1071'

--- a/data/yaml/gl/form/dynamic-content-focus.yaml
+++ b/data/yaml/gl/form/dynamic-content-focus.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  フォーカスを受け取ったときに、コンテンツの意味を変える、またはページ全体に及ぶような動的な変化を引き起こすフォーム・コントロールやコンポーネントを用いない。
+guideline:
+  ja: |-
+    フォーカスを受け取ったときに、コンテンツの意味を変える、またはページ全体に及ぶような動的な変化を引き起こすフォーム・コントロールやコンポーネントを用いない。
+  en: |-
+    Do not use form controls or components that, upon receiving focus, change the meaning of the content or cause dynamic changes affecting the entire page.
 sc:
 - 3.2.1
-intent: |-
-  視覚障害、認知障害があるユーザーが予期できない挙動を発生させない。
+intent:
+  ja: |-
+    視覚障害、認知障害があるユーザーが予期できない挙動を発生させない。
+  en: |-
+    Do not cause behaviors that are unexpected for users with visual or cognitive impairments.
 checks:
 - '0152'
 - '0171'

--- a/data/yaml/gl/form/errors-cancel.yaml
+++ b/data/yaml/gl/form/errors-cancel.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  法的行為、経済的取引、データの変更や削除を生じる機能については、取り消し、送信前の確認・修正、または送信時のエラー・チェックと修正を可能にする。
+guideline:
+  ja: |-
+    法的行為、経済的取引、データの変更や削除を生じる機能については、取り消し、送信前の確認・修正、または送信時のエラー・チェックと修正を可能にする。
+  en: |-
+    For functions involving legal commitments, financial transactions, or the alteration or deletion of data, enable cancellation, pre-submission confirmation and modification, or error checking and correction at the time of submission.
 sc:
 - 3.3.4
-intent: |-
-  誤操作による影響を少なくする。
+intent:
+  ja: |-
+    誤操作による影響を少なくする。
+  en: |-
+    Minimize the impact of misoperation.
 checks:
 - '1141'
 info:

--- a/data/yaml/gl/form/errors-correction.yaml
+++ b/data/yaml/gl/form/errors-correction.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  入力エラーがある場合に、修正方法を示す。
+guideline:
+  ja: |-
+    入力エラーがある場合に、修正方法を示す。
+  en: |-
+    When there are input errors, indicate methods for correction.
 sc:
 - 3.3.3
-intent: |-
-  フォーム入力における認知障害者、学習障害者の困難を軽減する。
+intent:
+  ja: |-
+    フォーム入力における認知障害者、学習障害者の困難を軽減する。
+  en: |-
+    Mitigate the difficulties faced by individuals with cognitive and learning disabilities in form input.
 checks:
 - '1111'
 - '1131'

--- a/data/yaml/gl/form/errors-identify.yaml
+++ b/data/yaml/gl/form/errors-identify.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  入力エラーがある場合、エラー箇所とエラー内容をテキストで知らせる。
+guideline:
+  ja: |-
+    入力エラーがある場合、エラー箇所とエラー内容をテキストで知らせる。
+  en: |-
+    When there are input errors, notify the user of the error location and error content by text.
 sc:
 - 3.3.1
-intent: |-
-  視覚障害者、色弱者が、エラー箇所を特定できるようにする。
+intent:
+  ja: |-
+    視覚障害者、色弱者が、エラー箇所を特定できるようにする。
+  en: |-
+    Enable individuals with visual impairments or color vision deficiencies to identify error locations.
 checks:
 - '1081'
 - '1101'

--- a/data/yaml/gl/form/hidden-label.yaml
+++ b/data/yaml/gl/form/hidden-label.yaml
@@ -7,15 +7,21 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  フォーム・コントロールに対して表示されているテキストを用いたラベル付けができない場合は、非表示のテキストを用いてラベルを付ける。
+guideline:
+  ja: |-
+    フォーム・コントロールに対して、表示されているテキストを用いたラベル付けができない場合は、非表示のテキストを用いてラベルを付ける。
+  en: |-
+    If the displayed text cannot be used as a label for a form control, use hidden text to label it.
 sc:
 - 1.1.1
 - 1.3.1
 - 2.4.6
 - 3.3.2
-intent: |-
-  視覚障害者が、フォーム・コントロールの目的を容易に判断することができるようにする。
+intent:
+  ja: |-
+    視覚障害者が、フォーム・コントロールの目的を容易に判断することができるようにする。
+  en: |-
+    Enable individuals with visual impairments to easily determine the purpose of form controls.
 checks:
 - '0931'
 - '0941'

--- a/data/yaml/gl/form/keyboard-operable.yaml
+++ b/data/yaml/gl/form/keyboard-operable.yaml
@@ -6,14 +6,20 @@ title:
   en: Enable Keyboard Operation
 platform:
 - web
-guideline: |-
-  すべてのフォーム・コントロールについて、キーボードによる操作を可能にする。
+guideline:
+  ja: |-
+    すべてのフォーム・コントロールについて、キーボードによる操作を可能にする。
+  en: |-
+    Enable keyboard operation for all form controls.
 sc:
 - 2.1.1
 - 2.1.3
 - 2.5.1
-intent: |-
-  マウスを使わない/使えない視覚障害者、肢体不自由者が、フォームの操作をできるようにする。
+intent:
+  ja: |-
+    マウスを使わない/使えない視覚障害者、肢体不自由者が、フォームの操作をできるようにする。
+  en: |-
+    Enable individuals with visual impairments or motor disabilities who do not use or cannot use a mouse to operate forms.
 checks:
 - '0172'
 - '0581'

--- a/data/yaml/gl/form/label.yaml
+++ b/data/yaml/gl/form/label.yaml
@@ -7,16 +7,22 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  フォーム・コントロールには、表示されているテキストをラベルとして明示的に関連付ける。
+guideline:
+  ja: |-
+    フォーム・コントロールには、表示されているテキストをラベルとして明示的に関連付ける。
+  en: |-
+    Explicitly associate displayed text with form controls as labels.
 sc:
 - 1.1.1
 - 1.3.1
 - 2.4.6
 - 2.5.3
 - 3.3.2
-intent: |-
-  視覚障害者が、フォーム・コントロールの目的を容易に判断することができるようにする。
+intent:
+  ja: |-
+    視覚障害者が、フォーム・コントロールの目的を容易に判断することができるようにする。
+  en: |-
+    Enable individuals with visual impairments to easily determine the purpose of form controls.
 checks:
 - '0931'
 - '0941'

--- a/data/yaml/gl/form/tab-order.yaml
+++ b/data/yaml/gl/form/tab-order.yaml
@@ -6,12 +6,18 @@ title:
   en: Appropriate Focus Order
 platform:
 - web
-guideline: |-
-  Tab/Shift+Tabキーでフォーカスを移動させたとき、コンテンツの意味に合った適切な順序でフォーカスを移動させる。
+guideline:
+  ja: |-
+    Tab/Shift+Tabキーでフォーカスを移動させたとき、コンテンツの意味に合った適切な順序でフォーカスを移動させる。
+  en: |-
+    When the focus is moved using the Tab/Shift+Tab keys, move the focus in an appropriate order that matches the meaning of the content.
 sc:
 - 2.4.3
-intent: |-
-  スクリーン・リーダーなどの支援技術がコンテンツを正しく認識し、ユーザーに適切な形で提示できるようにする。
+intent:
+  ja: |-
+    スクリーン・リーダーなどの支援技術がコンテンツを正しく認識し、ユーザーに適切な形で提示できるようにする。
+  en: |-
+    Enable assistive technologies such as screen readers to correctly recognize content and present it to users in an appropriate manner.
 checks:
 - '0172'
 info:

--- a/data/yaml/gl/form/target-size-mobile.yaml
+++ b/data/yaml/gl/form/target-size-mobile.yaml
@@ -6,15 +6,24 @@ title:
   en: Sufficiently Large Click/Touch Targets (Mobile)
 platform:
 - mobile
-guideline: |-
-  操作を受け付けるもののタッチのターゲット・サイズは充分に大きいものにする。
+guideline:
+  ja: |-
+    操作を受け付けるもののタッチのターゲット・サイズは充分に大きいものにする。
 
-  *  44 x 44 CSS px以上、または
-  *  OSのインターフェイス・ガイドラインを満たすサイズ
+    *  44 x 44 CSS px以上、または
+    *  OSのインターフェイス・ガイドラインを満たすサイズ
+  en: |-
+    Ensure that the touch targets for interactive elements are sufficiently large.
+
+    *  44 x 44 CSS px or larger, or
+    *  A size that meets the interface guidelines of the operating system.
 sc:
 - 2.5.5
-intent: |-
-  ロービジョン者、細かい手の動きが難しい肢体不自由者の、誤ったクリック/タッチ操作を防ぐ。
+intent:
+  ja: |-
+    ロービジョン者、細かい手の動きが難しい肢体不自由者の、誤ったクリック/タッチ操作を防ぐ。
+  en: |-
+    Prevent people with low vision and people with disabilities who have difficulty with fine motor control from making erroneous clicks/touches.
 checks:
 - '0334'
 info:

--- a/data/yaml/gl/form/target-size.yaml
+++ b/data/yaml/gl/form/target-size.yaml
@@ -6,15 +6,24 @@ title:
   en: Sufficiently Large Click/Touch Targets
 platform:
 - web
-guideline: |-
-  フォーム・コントロールの見た目をブラウザーのデフォルトのものから変更する場合、クリック/タッチのターゲット・サイズは充分に大きいものにする。
+guideline:
+  ja: |-
+    フォーム・コントロールの見た目をブラウザーのデフォルトのものから変更する場合、クリック/タッチのターゲット・サイズは充分に大きいものにする。
 
-  *  デスクトップ向けWebでは最低24 x 24 CSS px、可能であれば44 x 44 CSS px以上
-  *  モバイル向けWebでは44 x 44 CSS px以上
+    *  デスクトップ向けWebでは最低24 x 24 CSS px、可能であれば44 x 44 CSS px以上
+    *  モバイル向けWebでは44 x 44 CSS px以上
+  en: |-
+    When changing the appearance of form controls from the browser's default, ensure that the click/touch targets are sufficiently large.
+
+    *  For desktop web, 24 x 24 CSS px or larger, preferably 44 x 44 CSS px or larger.
+    *  For mobile web, 44 x 44 CSS px or larger.
 sc:
 - 2.5.5
-intent: |-
-  ロービジョン者、細かい手の動きが難しい肢体不自由者の、誤ったクリック/タッチ操作を防ぐ。
+intent:
+  ja: |-
+    ロービジョン者、細かい手の動きが難しい肢体不自由者の、誤ったクリック/タッチ操作を防ぐ。
+  en: |-
+    Prevent erroneous clicks/touches for users with low vision or those with physical disabilities that make fine hand movements difficult.
 checks:
 - '0332'
 - '0352'

--- a/data/yaml/gl/form/timing.yaml
+++ b/data/yaml/gl/form/timing.yaml
@@ -7,20 +7,33 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  フォームの入力や操作に制限時間を設けない。制限時間を設ける場合は、次に挙げる事項のうち、少なくとも1つを満たす。
+guideline:
+  ja: |-
+    フォームの入力や操作に制限時間を設けない。制限時間を設ける場合は、次に挙げる事項のうち、少なくとも1つを満たす。
 
-  -  解除： 制限時間があるフォームを利用する前に、ユーザーがその制限時間を解除することができる。又は、
-  -  調整： 制限時間があるフォームを利用する前に、ユーザーが少なくともデフォルト設定の10倍を超える、大幅な制限時間の調整をすることができる。又は、
-  -  延長： 時間切れになる前にユーザーに警告し、かつ少なくとも20秒間の猶予をもって、例えば「スペースキーを押す」などの簡単な操作により、ユーザーが制限時間を10回以上延長することができる。又は、
-  -  リアルタイムの例外： リアルタイムのイベント（例えば、オークション）において制限時間が必須の要素で、その制限時間に代わる手段が存在しない。又は、
-  -  必要不可欠な例外： 制限時間が必要不可欠なもので、制限時間を延長することがフォームを無効にすることになる。又は、
-  -  20時間の例外： 制限時間が20時間よりも長い。
+    -  解除： 制限時間があるフォームを利用する前に、ユーザーがその制限時間を解除することができる。又は、
+    -  調整： 制限時間があるフォームを利用する前に、ユーザーが少なくともデフォルト設定の10倍を超える、大幅な制限時間の調整をすることができる。又は、
+    -  延長： 時間切れになる前にユーザーに警告し、かつ少なくとも20秒間の猶予をもって、例えば「スペースキーを押す」などの簡単な操作により、ユーザーが制限時間を10回以上延長することができる。又は、
+    -  リアルタイムの例外： リアルタイムのイベント（例えば、オークション）において制限時間が必須の要素で、その制限時間に代わる手段が存在しない。又は、
+    -  必要不可欠な例外： 制限時間が必要不可欠なもので、制限時間を延長することがフォームを無効にすることになる。又は、
+    -  20時間の例外： 制限時間が20時間よりも長い。
+  en: |-
+    Do not set time limits for form input and operation. If time limits are set, at least one of the following conditions must be met:
+
+    -  Disabling: Users can disable the time limit before using a form with a time limit. Or,
+    -  Adjustment: Users can significantly adjust the time limit to exceed at least ten times the default setting before using a form with a time limit. Or,
+    -  Extension: Warn users before time expires, and allow them to extend the time limit by at least 20 seconds with a simple action, such as pressing the space key, at least ten times. Or,
+    -  Real-time Exception: The time limit is an essential part of a real-time event (e.g., an auction) where no alternative to the time limit exists. Or,
+    -  Essential Exception: The time limit is essential and extending it would invalidate the form. Or,
+    -  20-hour Exception: The time limit is longer than 20 hours.
 sc:
 - 2.2.1
 - 2.2.3
-intent: |-
-  コンテンツの読み取りや理解に時間がかかる場合や、入力操作などに時間がかかる場合にも問題なくフォームを利用できるようにする。
+intent:
+  ja: |-
+    コンテンツの読み取りや理解に時間がかかる場合や、入力操作などに時間がかかる場合にも問題なくフォームを利用できるようにする。
+  en: |-
+    Ensure that forms can be used without issue even when it takes time to read or understand the content, or when input operations take time.
 checks:
 - '0961'
 info:

--- a/data/yaml/gl/icon/color-only.yaml
+++ b/data/yaml/gl/icon/color-only.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  アイコンに付与されているラベルが非表示のテキストの場合は、形状、サイズが同じで色だけが違う複数のアイコンを用いない。
+guideline:
+  ja: |-
+    アイコンに付与されているラベルが非表示のテキストの場合は、形状、サイズが同じで色だけが違う複数のアイコンを用いない。
+  en: |-
+    If labels attached to icons are non-visible text, do not use multiple icons that are identical in shape and size but differ only in color.
 sc:
 - 1.4.1
-intent: |-
-  視覚障害者や色弱者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    視覚障害者や色弱者が、コンテンツを利用できるようにする。
+  en: |-
+    Enable individuals with visual impairments or color vision deficiencies to use content.
 checks:
 - '0391'
 - '0412'

--- a/data/yaml/gl/icon/consistent.yaml
+++ b/data/yaml/gl/icon/consistent.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  同じ目的で用いられるアイコンには、サイト内で一貫性のある画像とテキストを用いる。
+guideline:
+  ja: |-
+    同じ目的で用いられるアイコンには、サイト内で一貫性のある画像とテキストを用いる。
+  en: |-
+    Use consistent images and text throughout the site for icons that serve the same purpose.
 sc:
 - 3.2.4
-intent: |-
-  予測可能性を上げ、混乱を防ぐ。
+intent:
+  ja: |-
+    予測可能性を上げ、混乱を防ぐ。
+  en: |-
+    Increase predictability and prevent confusion.
 checks:
 - '0242'
 - '0262'

--- a/data/yaml/gl/icon/contrast.yaml
+++ b/data/yaml/gl/icon/contrast.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  背景色とのコントラスト比を3:1以上にする。
+guideline:
+  ja: |-
+    背景色とのコントラスト比を3:1以上にする。
+  en: |-
+    Ensure a contrast ratio of at least 3:1 with the background color.
 sc:
 - 1.4.11
-intent: |-
-  ロービジョン者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    ロービジョン者が、コンテンツを利用できるようにする。
+  en: |-
+    Enable individuals with low vision to use content.
 checks:
 - '0001'
 info:

--- a/data/yaml/gl/icon/target-size-mobile.yaml
+++ b/data/yaml/gl/icon/target-size-mobile.yaml
@@ -6,15 +6,24 @@ title:
   en: Sufficiently Large Click/Touch Targets (Mobile)
 platform:
 - mobile
-guideline: |-
-  画像をリンクやボタンにする場合、クリック/タッチのターゲット・サイズは充分に大きいものにする。
+guideline:
+  ja: |-
+    画像をリンクやボタンにする場合、クリック/タッチのターゲット・サイズは充分に大きいものにする。
 
-  *  44 x 44 CSS px以上、または
-  *  OSのインターフェイス・ガイドラインを満たすサイズ
+    *  44 x 44 CSS px以上、または
+    *  OSのインターフェイス・ガイドラインを満たすサイズ
+  en: |-
+    When using images as links or buttons, ensure that the click/touch target size is sufficiently large.
+
+    *  44 x 44 CSS px or larger, or
+    *  A size that meets the interface guidelines of the operating system.
 sc:
 - 2.5.5
-intent: |-
-  ロービジョン者、細かい手の動きが難しい肢体不自由者の、誤ったクリック/タッチ操作を防ぐ。
+intent:
+  ja: |-
+    ロービジョン者、細かい手の動きが難しい肢体不自由者の、誤ったクリック/タッチ操作を防ぐ。
+  en: |-
+    Prevent erroneous clicks/touches for users with low vision or those with physical disabilities that make fine hand movements difficult.
 checks:
 - '0333'
 info:

--- a/data/yaml/gl/icon/target-size.yaml
+++ b/data/yaml/gl/icon/target-size.yaml
@@ -6,15 +6,24 @@ title:
   en: Sufficiently Large Click/Touch Targets
 platform:
 - web
-guideline: |-
-  画像をリンクやボタンにする場合、クリック/タッチのターゲット・サイズは充分に大きいものにする。
+guideline:
+  ja: |-
+    画像をリンクやボタンにする場合、クリック/タッチのターゲット・サイズは充分に大きいものにする。
 
-  -  デスクトップ向けWebでは最低24 x 24 CSS px、可能であれば44 x 44 CSS px以上
-  -  モバイル向けWebでは44 x 44 CSS px以上
+    -  デスクトップ向けWebでは最低24 x 24 CSS px、可能であれば44 x 44 CSS px以上
+    -  モバイル向けWebでは44 x 44 CSS px以上
+  en: |-
+    When using images as links or buttons, ensure that the click/touch target size is sufficiently large.
+
+    -  For desktop web, 24 x 24 CSS px or larger, preferably 44 x 44 CSS px or larger.
+    -  For mobile web, 44 x 44 CSS px or larger.
 sc:
 - 2.5.5
-intent: |-
-  ロービジョン者、細かい手の動きが難しい肢体不自由者の、誤ったクリック/タッチ操作を防ぐ。
+intent:
+  ja: |-
+    ロービジョン者、細かい手の動きが難しい肢体不自由者の、誤ったクリック/タッチ操作を防ぐ。
+  en: |-
+    Prevent erroneous clicks/touches for users with low vision or those with physical disabilities that make fine hand movements difficult.
 checks:
 - '0331'
 - '0351'

--- a/data/yaml/gl/icon/visible-label.yaml
+++ b/data/yaml/gl/icon/visible-label.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  アイコンにはテキストのラベルを併せて表示し、それが難しい場合はアイコンの目的（表している状態、操作の結果）が分かるような代替テキストを付与する。
+guideline:
+  ja: |-
+    アイコンにはテキストのラベルを併せて表示し、それが難しい場合はアイコンの目的（表している状態、操作の結果）が分かるような代替テキストを付与する。
+  en: |-
+    Display text labels together with icons, and if that is not possible, provide alternative text that indicates the purpose of the icon (the state it represents or the expected result of the operation).
 sc:
 - 1.1.1
-intent: |-
-  視覚障害者が画像の存在を認知し、内容を理解できるようにする。
+intent:
+  ja: |-
+    視覚障害者が画像の存在を認知し、内容を理解できるようにする。
+  en: |-
+    Enable individuals with visual impairments to perceive the presence of images and understand their content.
 checks:
 - '0391'
 - '0401'

--- a/data/yaml/gl/image/adjacent-contrast.yaml
+++ b/data/yaml/gl/image/adjacent-contrast.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  画像の隣接領域の色とのコントラスト比を3:1以上にする。
+guideline:
+  ja: |-
+    画像の隣接領域の色とのコントラスト比を3:1以上にする。
+  en: |-
+    Ensure that the contrast ratio between the image and the adjacent color areas is at least 3:1.
 sc:
 - 1.4.11
-intent: |-
-  ロービジョン者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    ロービジョン者が、コンテンツを利用できるようにする。
+  en: |-
+    Enable individuals with low vision to use content.
 checks:
 - '0001'
 info:

--- a/data/yaml/gl/image/color-only.yaml
+++ b/data/yaml/gl/image/color-only.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  特定の色に何らかの意味を持たせている場合、形状、模様など他の視覚的な要素も併せて用い、色が判別できなくてもその意味を理解できるようにする。
+guideline:
+  ja: |-
+    特定の色に何らかの意味を持たせている場合、形状、模様など他の視覚的な要素も併せて用い、色が判別できなくてもその意味を理解できるようにする。
+  en: |-
+    When associating specific meanings with certain colors, also use other visual elements such as shapes or patterns to ensure that the meaning is understandable even if the color cannot be discerned.
 sc:
 - 1.4.1
-intent: |-
-  視覚障害者や色弱者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    視覚障害者や色弱者が、コンテンツを利用できるようにする。
+  en: |-
+    Enable individuals with visual impairments or color vision deficiencies to use content.
 checks:
 - '0031'
 - '0051'

--- a/data/yaml/gl/image/decorative.yaml
+++ b/data/yaml/gl/image/decorative.yaml
@@ -7,10 +7,16 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  純粋な装飾目的の画像は、スクリーン・リーダーなどの支援技術が無視するようにする。
-intent: |-
-  不要な情報が提示されないようにすることで、視覚障害者などの情報取得をスムースにする。
+guideline:
+  ja: |-
+    純粋な装飾目的の画像は、スクリーン・リーダーなどの支援技術が無視するようにする。
+  en: |-
+    Ensure that images used purely for decorative purposes are ignored by assistive technologies like screen readers.
+intent:
+  ja: |-
+    不要な情報が提示されないようにすることで、視覚障害者の情報取得をスムースにする。
+  en: |-
+    Ensure that unnecessary information is not presented, to facilitate smooth information acquisition for visually impaired individuals.
 checks:
 - '0451'
 - '0461'

--- a/data/yaml/gl/image/description.yaml
+++ b/data/yaml/gl/image/description.yaml
@@ -7,10 +7,16 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  画像に関する過不足のない説明をテキストで提供する。
-intent: |-
-  視覚障害者が画像の存在を認知し、内容を理解できるようにする。
+guideline:
+  ja: |-
+    画像に関する過不足のない説明をテキストで提供する。
+  en: |-
+    Provide a text description for images that conveys equivalent information.
+intent:
+  ja: |-
+    視覚障害者が画像の存在を認知し、内容を理解できるようにする。
+  en: |-
+    Ensure that users with visual impairments can perceive the presence of images and understand their content.
 checks:
 - '0421'
 - '0431'

--- a/data/yaml/gl/image/mobile-text-contrast.yaml
+++ b/data/yaml/gl/image/mobile-text-contrast.yaml
@@ -6,22 +6,37 @@ title:
   en: Contrast Ratio of Text in Images on Mobile OS
 platform:
 - mobile
-guideline: |-
-  画像内のテキストや、重要な情報を伝える視覚的要素の色と背景の色に、十分なコントラストを確保する。
+guideline:
+  ja: |-
+    画像内のテキストや、重要な情報を伝える視覚的要素の色と背景の色に、十分なコントラストを確保する。
 
-  -  テキストの文字サイズが24px（18pt）以上の場合：3:1以上
-  -  テキストの文字サイズが19px（14pt）以上で太字の場合：3:1以上
-  -  その他の場合： 4.5:1以上
+    -  テキストの文字サイズが24px（18pt）以上の場合：3:1以上
+    -  テキストの文字サイズが19px（14pt）以上で太字の場合：3:1以上
+    -  その他の場合： 4.5:1以上
 
-  注：モバイル・アプリケーションにおいては、デスクトップのWebと比較して文字サイズの変更方法が広く知られていると推測されること、各プラットフォームのガイドライン [#]_ [#]_ においてもWCAG 2.1に準じた基準を用いていることから、上記の基準としています。
+    注：モバイル・アプリケーションにおいては、デスクトップのWebと比較して文字サイズの変更方法が広く知られていると推測されること、各プラットフォームのガイドライン [#]_ [#]_ においてもWCAG 2.1に準じた基準を用いていることから、上記の基準としています。
 
-  .. [#] `アクセシビリティ | Apple Developer Documentation <https://developer.apple.com/jp/design/human-interface-guidelines/accessibility>`_
-  .. [#] `Accessibility – Material Design 3 <https://m3.material.io/foundations/accessible-design/patterns#f72f3851-5184-4132-b871-bc8224e062e2>`_
+    .. [#] `アクセシビリティ | Apple Developer Documentation <https://developer.apple.com/jp/design/human-interface-guidelines/accessibility>`_
+    .. [#] `Accessibility – Material Design 3 <https://m3.material.io/foundations/accessible-design/patterns#f72f3851-5184-4132-b871-bc8224e062e2>`_
+  en: |-
+    Ensure sufficient contrast between the colors of text within images and key visual elements conveying important information, and their background colors.
+
+    -  For text size 24px (18pt) or larger: a contrast ratio of at least 3:1.
+    -  For bold text 19px (14pt) or larger: a contrast ratio of at least 3:1.
+    -  In other cases: a contrast ratio of at least 4.5:1.
+
+    Note: In mobile applications, it is assumed that methods for changing text size are more widely known compared to desktop web, and the guidelines of each platform [#]_ [#]_ also use standards in line with WCAG 2.1, hence the above criteria are set.
+
+    .. [#] `Accessibility | Apple Developer Documentation <https://developer.apple.com/design/human-interface-guidelines/accessibility>`_
+    .. [#] `Accessibility – Material Design 3 <https://m3.material.io/foundations/accessible-design/patterns#f72f3851-5184-4132-b871-bc8224e062e2>`_
 sc:
 - 1.4.3
 - 1.4.6
-intent: |-
-  ロービジョン者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    ロービジョン者が、コンテンツを利用できるようにする。
+  en: |-
+    Ensure that users with low vision can use the content.
 checks:
 - '0003'
 info:

--- a/data/yaml/gl/image/text-contrast.yaml
+++ b/data/yaml/gl/image/text-contrast.yaml
@@ -6,22 +6,37 @@ title:
   en: Contrast Ratio of Text in Images
 platform:
 - web
-guideline: |-
-  画像内のテキストや、重要な情報を伝える視覚的要素の色と背景の色に、十分なコントラストを確保する。
+guideline:
+  ja: |-
+    画像内のテキストや、重要な情報を伝える視覚的要素の色と背景の色に、十分なコントラストを確保する。
   
-  -  テキストの文字サイズが29px（22pt）以上の場合： 3:1以上
-  -  テキストの文字サイズが24px（18pt）以上で太字の場合： 3:1以上
-  -  その他の場合： 4.5:1以上
+    -  テキストの文字サイズが29px（22pt）以上の場合： 3:1以上
+    -  テキストの文字サイズが24px（18pt）以上で太字の場合： 3:1以上
+    -  その他の場合： 4.5:1以上
 
-  注：freeeのプロダクトやWebサイトにおいては、主に日本語が用いられているため、Understanding WCAG 2.1 [#]_ の日本語訳 [#]_ 中の訳注で示されている基準を用いています。
+    注：freeeのプロダクトやWebサイトにおいては、主に日本語が用いられているため、Understanding WCAG 2.1 [#]_ の日本語訳 [#]_ 中の訳注で示されている基準を用いています。
 
-  .. [#] `Understanding Success Criterion 1.4.3: Contrast (Minimum) <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html>`_
-  .. [#] `達成基準 1.4.3: コントラスト (最低限)を理解する <https://waic.jp/translations/WCAG21/Understanding/contrast-minimum.html>`_
+    .. [#] `Understanding Success Criterion 1.4.3: Contrast (Minimum) <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html>`_
+    .. [#] `達成基準 1.4.3: コントラスト (最低限)を理解する <https://waic.jp/translations/WCAG21/Understanding/contrast-minimum.html>`_
+  en: |-
+    Ensure sufficient contrast between the colors of text within images and key visual elements conveying important information, and their background colors.
+
+    -  For text size 29px (22pt) or larger: a contrast ratio of at least 3:1.
+    -  For bold text 24px (18pt) or larger: a contrast ratio of at least 3:1.
+    -  In other cases: a contrast ratio of at least 4.5:1.
+
+    Note: In freee products and websites, Japanese is mainly used, so the criteria indicated in the translation notes in Understanding WCAG 2.1 [#]_ [#]_  are used.
+
+    .. [#] `Understanding Success Criterion 1.4.3: Contrast (Minimum) <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html>`_
+    .. [#] `達成基準 1.4.3: コントラスト (最低限)を理解する <https://waic.jp/translations/WCAG21/Understanding/contrast-minimum.html>`_
 sc:
 - 1.4.3
 - 1.4.6
-intent: |-
-  ロービジョン者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    ロービジョン者が、コンテンツを利用できるようにする。
+  en: |-
+    Ensure that users with low vision can use the content.
 checks:
 - '0002'
 info:

--- a/data/yaml/gl/images_of_text/avoid-usage.yaml
+++ b/data/yaml/gl/images_of_text/avoid-usage.yaml
@@ -7,15 +7,21 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  画像化されたテキストを用いないと実現できない表現が不可欠な場合（例： ロゴ）を除いて、文字情報は画像化せず、テキスト・データで提供する。
+guideline:
+  ja: |-
+    画像化されたテキストを用いないと実現できない表現が不可欠な場合（例： ロゴ）を除いて、文字情報は画像化せず、テキスト・データで提供する。
+  en: |-
+    Unless the use of images of text is essential for the expression (e.g. logos), provide character information as text data instead of images of text.
 sc:
 - 1.4.5
 - 1.4.9
-intent: |-
-  スクリーン・リーダーのユーザーがアクセスしやすい形で情報を提示する。
-
-  テキスト情報の扱いやすさを損ねない。
+intent:
+  ja: |-
+    -  スクリーン・リーダーのユーザーがアクセスできる形で情報を提示する。
+    -  テキスト情報の扱いやすさを損ねない。
+  en: |-
+    -  Present information in a form that can be accessed by screen reader users.
+    -  Do not compromise the ease of handling text information.
 checks:
 - '0481'
 - '0501'

--- a/data/yaml/gl/images_of_text/mobile-text-contrast.yaml
+++ b/data/yaml/gl/images_of_text/mobile-text-contrast.yaml
@@ -6,22 +6,37 @@ title:
   en: Contrast Ratio of Text in Images on Mobile OS
 platform:
 - mobile
-guideline: |-
-  画像化されたテキストの色と背景の色に十分なコントラスト比を確保する。
+guideline:
+  ja: |-
+    画像化されたテキストの色と背景の色に十分なコントラスト比を確保する。
 
-  -  テキストの文字サイズが24px（18pt）以上の場合：3:1以上
-  -  テキストの文字サイズが19px（14pt）以上で太字の場合：3:1以上
-  -  その他の場合： 4.5:1以上
+    -  テキストの文字サイズが24px（18pt）以上の場合：3:1以上
+    -  テキストの文字サイズが19px（14pt）以上で太字の場合：3:1以上
+    -  その他の場合： 4.5:1以上
 
-  注：モバイル・アプリケーションにおいては、デスクトップのWebと比較して文字サイズの変更方法が広く知られていると推測されること、各プラットフォームのガイドライン [#]_ [#]_ においてもWCAG 2.1に準じた基準を用いていることから、上記の基準としています。
+    注：モバイル・アプリケーションにおいては、デスクトップのWebと比較して文字サイズの変更方法が広く知られていると推測されること、各プラットフォームのガイドライン [#]_ [#]_ においてもWCAG 2.1に準じた基準を用いていることから、上記の基準としています。
 
-  .. [#] `アクセシビリティ | Apple Developer Documentation <https://developer.apple.com/jp/design/human-interface-guidelines/accessibility>`_
-  .. [#] `Accessibility – Material Design 3 <https://m3.material.io/foundations/accessible-design/patterns#f72f3851-5184-4132-b871-bc8224e062e2>`_
+    .. [#] `アクセシビリティ | Apple Developer Documentation <https://developer.apple.com/jp/design/human-interface-guidelines/accessibility>`_
+    .. [#] `Accessibility – Material Design 3 <https://m3.material.io/foundations/accessible-design/patterns#f72f3851-5184-4132-b871-bc8224e062e2>`_
+  en: |-
+    Ensure a sufficient contrast ratio between the colors of images of text and their background colors.
+
+    -  For text size 24px (18pt) or larger: a contrast ratio of at least 3:1.
+    -  For bold text 19px (14pt) or larger: a contrast ratio of at least 3:1.
+    -  In other cases: a contrast ratio of at least 4.5:1.
+
+    Note: In mobile applications, it is assumed that methods for changing text size are more widely known compared to desktop web, and the guidelines of each platform [#]_ [#]_ also use standards in line with WCAG 2.1, hence the above criteria are set.
+
+    .. [#] `Accessibility | Apple Developer Documentation <https://developer.apple.com/design/human-interface-guidelines/accessibility>`_
+    .. [#] `Accessibility – Material Design 3 <https://m3.material.io/foundations/accessible-design/patterns#f72f3851-5184-4132-b871-bc8224e062e2>`_
 sc:
 - 1.4.3
 - 1.4.6
-intent: |-
-  ロービジョン者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    ロービジョン者が、コンテンツを利用できるようにする。
+  en: |-
+    Ensure that users with low vision can use the content.
 checks:
 - '0003'
 info:

--- a/data/yaml/gl/images_of_text/provide-text.yaml
+++ b/data/yaml/gl/images_of_text/provide-text.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  画像化されたテキストに含まれる文字情報をテキストでも提供する。
+guideline:
+  ja: |-
+    画像化されたテキストに含まれる文字情報をテキストでも提供する。
+  en: |-
+    Provide character information included in images of text as text.
 sc:
 - 1.1.1
-intent: |-
-  スクリーン・リーダーのユーザーが画像化されたテキストにアクセスできるようにする。
+intent:
+  ja: |-
+    スクリーン・リーダーのユーザーが画像化されたテキストにアクセスできるようにする。
+  en: |-
+    Ensure that screen reader users can access images of text.
 checks:
 - '0511'
 - '0521'

--- a/data/yaml/gl/images_of_text/text-contrast.yaml
+++ b/data/yaml/gl/images_of_text/text-contrast.yaml
@@ -6,22 +6,37 @@ title:
   en: Contrast Ratio of Text in Images
 platform:
 - web
-guideline: |-
-  画像化されたテキストの色と背景の色に十分なコントラスト比を確保する。
+guideline:
+  ja: |-
+    画像化されたテキストの色と背景の色に十分なコントラスト比を確保する。
 
-  -  テキストの文字サイズが29px（22pt）以上の場合： 3:1以上
-  -  テキストの文字サイズが24px（18pt）以上で太字の場合： 3:1以上
-  -  その他の場合： 4.5:1以上
+    -  テキストの文字サイズが29px（22pt）以上の場合： 3:1以上
+    -  テキストの文字サイズが24px（18pt）以上で太字の場合： 3:1以上
+    -  その他の場合： 4.5:1以上
 
-  注：freeeのプロダクトやWebサイトにおいては、主に日本語が用いられているため、Understanding WCAG 2.1 [#]_ の日本語訳 [#]_ 中の訳注で示されている基準を用いています。
+    注：freeeのプロダクトやWebサイトにおいては、主に日本語が用いられているため、Understanding WCAG 2.1 [#]_ の日本語訳 [#]_ 中の訳注で示されている基準を用いています。
 
-  .. [#] `Understanding Success Criterion 1.4.3: Contrast (Minimum) <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html>`_
-  .. [#] `達成基準 1.4.3: コントラスト (最低限)を理解する <https://waic.jp/translations/WCAG21/Understanding/contrast-minimum.html>`_
+    .. [#] `Understanding Success Criterion 1.4.3: Contrast (Minimum) <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html>`_
+    .. [#] `達成基準 1.4.3: コントラスト (最低限)を理解する <https://waic.jp/translations/WCAG21/Understanding/contrast-minimum.html>`_
+  en: |-
+    Ensure a sufficient contrast ratio between the colors of images of text and their background colors.
+
+    -  For text size 29px (22pt) or larger: a contrast ratio of at least 3:1.
+    -  For bold text 24px (18pt) or larger: a contrast ratio of at least 3:1.
+    -  In other cases: a contrast ratio of at least 4.5:1.
+
+    Note: In freee products and websites, Japanese is mainly used, so the criteria indicated in the translation notes in Understanding WCAG 2.1 [#]_ [#]_ are used.
+
+    .. [#] `Understanding Success Criterion 1.4.3: Contrast (Minimum) <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html>`_
+    .. [#] `達成基準 1.4.3: コントラスト (最低限)を理解する <https://waic.jp/translations/WCAG21/Understanding/contrast-minimum.html>`_
 sc:
 - 1.4.3
 - 1.4.6
-intent: |-
-  ロービジョン者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    ロービジョン者が、コンテンツを利用できるようにする。
+  en: |-
+    Ensure that users with low vision can use the content.
 checks:
 - '0002'
 info:

--- a/data/yaml/gl/input_device/focus-indicator.yaml
+++ b/data/yaml/gl/input_device/focus-indicator.yaml
@@ -6,12 +6,18 @@ title:
   en: Visualization of Focus Areas
 platform:
 - web
-guideline: |-
-  キーボードで操作可能な要素について、フォーカス・インジケーターを消さない。
+guideline:
+  ja: |-
+    キーボードで操作可能な要素について、フォーカス・インジケーターを消さない。
+  en: |-
+    Do not remove focus indicators from elements that can be operated by keyboard.
 sc:
 - 2.4.7
-intent: |-
-  キーボードのみを使っている場合でも、フォーカスされている箇所が分かるようにし、操作を可能にする。
+intent:
+  ja: |-
+    キーボードのみを使っている場合でも、フォーカスされている箇所が分かるようにし、操作を可能にする。
+  en: |-
+    Ensure that the focused area is discernible and operable even when using only a keyboard.
 checks:
 - '0151'
 - '0171'

--- a/data/yaml/gl/input_device/focus.yaml
+++ b/data/yaml/gl/input_device/focus.yaml
@@ -7,13 +7,19 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  キーボード操作時のTab/Shift+Tabキー操作、スクリーン・リーダー利用時のタッチUIでの左右フリック操作などでフォーカスを移動させたとき、コンテンツの意味に合った適切な順序でフォーカスを移動させる。
+guideline:
+  ja: |-
+    キーボード操作時のTab/Shift+Tabキー操作、スクリーン・リーダー利用時のタッチUIでの左右フリック操作などでフォーカスを移動させたとき、コンテンツの意味に合った適切な順序でフォーカスを移動させる。
+  en: |-
+    When moving focus using keyboard operations like Tab/Shift+Tab keys, or touch UI left/right flick operations with screen readers, ensure that focus moves in an appropriate sequence that aligns with the content's meaning.
 sc:
 - 1.3.2
 - 2.4.3
-intent: |-
-  スクリーン・リーダーなどの支援技術のユーザーや、キーボードのみで操作しているユーザーが適切にコンテンツを利用できるようにする。
+intent:
+  ja: |-
+    スクリーン・リーダーなどの支援技術のユーザーや、キーボードのみで操作しているユーザーが適切にコンテンツを利用できるようにする。
+  en: |-
+    Ensure that users of assistive technologies such as screen readers and users who operate only with a keyboard can use content appropriately.
 checks:
 - '0172'
 info:

--- a/data/yaml/gl/input_device/independent.yaml
+++ b/data/yaml/gl/input_device/independent.yaml
@@ -7,18 +7,29 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  そのプラットフォームで標準的ではない入力手段を使用しないとアクセスできない情報や利用できない機能がない。
-  
-  プラットフォームの標準的な入力手段とは、Webではキーボード、モバイルではOS標準のタッチ操作を指す。また、文字入力に関しては、Windowsのタッチ操作、iOSやAndroidでキーボードを接続した操作もプラットフォームの標準的な入力手段に当たる。
+guideline:
+  ja: |-
+    そのプラットフォームで標準的ではない入力手段を使用しないとアクセスできない情報や利用できない機能がない。
+    
+    プラットフォームの標準的な入力手段とは、Webではキーボード、モバイルではOS標準のタッチ操作を指す。また、文字入力に関しては、Windowsのタッチ操作、iOSやAndroidでキーボードを接続した操作もプラットフォームの標準的な入力手段に当たる。
+  en: |-
+    There are no inaccessible pieces of information or unusable functions that require non-standard input methods for that platform.
+
+    Standard input methods for the platform refer to the keyboard for the web, and OS-standard touch operations for mobile. Additionally, for text input, touch operations on Windows, and operations using a connected keyboard on iOS or Android, are also considered standard input methods for the platform.
 sc:
 - 2.5.4
 - 2.5.6
-intent: |-
-  ニーズに応じた異なる多様な入力手段の使用を妨げない。
+intent:
+  ja: |-
+    ニーズに応じた異なる多様な入力手段の使用を妨げない。
 
-  *  スマートフォンでタッチUIだけでなくキーボードを利用することも阻害しないことで、上肢障害や視覚障害があるユーザーの負担を軽減できる。
-  *  加速度センサーなど動きを伴う動作を前提とした操作（例：シェークで取り消し）だけで実行できる機能を作らないことで、肢体不自由のユーザーの利用を阻害しない。
+    *  スマートフォンでタッチUIだけでなくキーボードを利用することも阻害しないことで、上肢障害や視覚障害があるユーザーの負担を軽減できる。
+    *  加速度センサーなど動きを伴う動作を前提とした操作（例：シェークで取り消し）だけで実行できる機能を作らないことで、肢体不自由のユーザーの利用を阻害しない。
+  en: |-
+    Do not hinder the use of diverse input methods tailored to different needs.
+
+    *  By not impeding the use of keyboards on smartphones, in addition to touch UIs, the burden on users with upper limb disabilities or visual impairments can be reduced.
+    *  By not creating functions that can only be executed through operations that assume motion, such as using an accelerometer (for example, shake to undo), the use by users with physical disabilities is not hindered."
 checks:
 - '0362'
 - '0371'

--- a/data/yaml/gl/input_device/keyboard-operable.yaml
+++ b/data/yaml/gl/input_device/keyboard-operable.yaml
@@ -6,14 +6,20 @@ title:
   en: Enable Keyboard Operation
 platform:
 - web
-guideline: |-
-  マウスまたはタッチUIを使わないと実行できないような機能を作らず、キーボードによる操作を可能にする。
+guideline:
+  ja: |-
+    マウスまたはタッチUIを使わないと実行できないような機能を作らず、キーボードによる操作を可能にする。
+  en: |-
+    Do not create functions that cannot be executed without using a mouse or touch UI, and ensure that operation by keyboard is also possible.
 sc:
 - 2.1.1
 - 2.1.3
 - 2.5.1
-intent: |-
-  マウスを使わない/使えない視覚障害者、肢体不自由者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    マウスを使わない/使えない視覚障害者、肢体不自由者が、コンテンツを利用できるようにする。
+  en: |-
+    Ensure that users with visual impairments or physical disabilities who cannot or do not use a mouse can use content.
 checks:
 - '0172'
 - '0211'

--- a/data/yaml/gl/input_device/no-trap.yaml
+++ b/data/yaml/gl/input_device/no-trap.yaml
@@ -6,12 +6,18 @@ title:
   en: Avoid Keyboard Traps
 platform:
 - web
-guideline: |-
-  ページ中のあらゆるコンポーネントについて、Tabキー、矢印キー、Escキーなど簡単な操作でフォーカスを外すことができるようにする。
+guideline:
+  ja: |-
+    ページ中のあらゆるコンポーネントについて、Tabキー、矢印キー、Escキーの押下など簡単な操作でフォーカスを外すことができるようにする。
+  en: |-
+    Ensure that focus can be moved off from every component on a page using simple operations such as pressing the Tab key, arrow keys, and Esc key.
 sc:
 - 2.1.2
-intent: |-
-  キーボードのみを利用している場合に、ページ中の特定のコンポーネントがページの他の部分へのアクセスを阻害しないようにする。
+intent:
+  ja: |-
+    キーボードのみを利用している場合に、ページ中の特定のコンポーネントがページの他の部分へのアクセスを阻害しないようにする。
+  en: |-
+    Ensure that specific components on a page do not prevent access to other parts of the page when using only a keyboard.
 checks:
 - '0201'
 info:

--- a/data/yaml/gl/input_device/shortcut-keys.yaml
+++ b/data/yaml/gl/input_device/shortcut-keys.yaml
@@ -6,16 +6,26 @@ title:
   en: When Providing Shortcut Keys
 platform:
 - web
-guideline: |-
-  ショートカットキーを提供する場合は、以下のいずれかを満たす。
+guideline:
+  ja: |-
+    ショートカットキーを提供する場合は、以下のいずれかを満たす。
 
-  -  ショートカットキーを無効にする設定を可能にする。
-  -  ショートカットキーの割り当ての変更を可能にする。
-  -  操作対象にフォーカスがあるときのみショートカットキーが有効になるようにする。
+    -  ショートカットキーを無効にする設定を可能にする。
+    -  ショートカットキーの割り当ての変更を可能にする。
+    -  操作対象にフォーカスがあるときのみショートカットキーが有効になるようにする。
+  en: |-
+    When providing shortcut keys, satisfy one of the following:
+
+    -  Allow users to disable shortcut keys.
+    -  Allow users to change the assignment of shortcut keys.
+    -  Enable shortcut keys only when the target of the operation has focus.
 sc:
 - 2.1.4
-intent: |-
-  音声認識で操作している場合に、ショートカットキーに割り当てられている機能が誤って実行されないようにする。
+intent:
+  ja: |-
+    音声認識で操作している場合に、ショートカットキーに割り当てられている機能が誤って実行されないようにする。
+  en: |-
+    Ensure that functions assigned to shortcut keys are not executed accidentally when operating with voice recognition.
 checks:
 - '0141'
 info:

--- a/data/yaml/gl/input_device/support-mobile-assistive-tech.yaml
+++ b/data/yaml/gl/input_device/support-mobile-assistive-tech.yaml
@@ -6,22 +6,35 @@ title:
   en: Support for Mobile Assistive Technologies
 platform:
 - mobile
-guideline: |-
-  OS標準のスクリーン・リーダーの利用時、以下を満たす。
+guideline:
+  ja: |-
+    OS標準のスクリーン・リーダーの利用時、以下を満たす。
 
-  *  操作を受け付けるすべてのUIコンポーネントは、スクリーン・リーダーでフォーカスし、操作することができる
-  *  画面に表示されているすべての情報は、スクリーン・リーダーでフォーカスし、内容を確認できる
-  *  スクリーン・リーダーのフォーカス箇所を示す表示が視認できる配色になっている
+    *  操作を受け付けるすべてのUIコンポーネントは、スクリーン・リーダーでフォーカスし、操作することができる
+    *  画面に表示されているすべての情報は、スクリーン・リーダーでフォーカスし、内容を確認できる
+    *  スクリーン・リーダーのフォーカス箇所を示す表示が視認できる配色になっている
 
-  OS標準のスクリーン・リーダーとは、iOS、iPadOSではVoiceOver、AndroidではTalkBackを差す。
+    OS標準のスクリーン・リーダーとは、iOS、iPadOSではVoiceOver、AndroidではTalkBackを差す。
+  en: |-
+    When using the standard screen readers of the OS, the following must be met:
+
+    *  All UI components that receive operations can be focused on and operated by the screen reader.
+    *  All information displayed on the screen can be focused on by the screen reader and its content can be read.
+    *  The display indicating the focus area of the screen reader is in a color scheme that is visible.
+
+    The standard screen readers for the OS refer to VoiceOver for iOS and iPadOS, and TalkBack for Android.
 sc:
 - 1.4.11
 - 4.1.2
-intent: |-
-  -  視覚障害者がコンテンツを利用できるようにする。
-  -  音声入力やスイッチを用いたインターフェースなど、スクリーン・リーダー以外の支援技術による利用を可能にする。
+intent:
+  ja: |-
+    -  視覚障害者がコンテンツを利用できるようにする。
+    -  音声入力やスイッチを用いたインターフェースなど、スクリーン・リーダー以外の支援技術による利用を可能にする。
+  en: |-
+    -  Ensure that people with visual impairments can use content.
+    -  Enable the use of assistive technologies other than screen readers, such as voice input and switch interfaces.
 checks:
-  - '0153'
-  - '0172'
-  - '0581'
-  - '0586'
+- '0153'
+- '0172'
+- '0581'
+- '0586'

--- a/data/yaml/gl/input_device/use-up-event.yaml
+++ b/data/yaml/gl/input_device/use-up-event.yaml
@@ -7,17 +7,28 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  クリックやタップで実行される機能の実行、完了のトリガーには、ダウン・イベント（mousedown, touchdownなど）を使わず、アップ・イベント（mouseup, touchupなど）やクリック・イベント（clickなど）を使い、誤った操作を中断できるようにする。
+guideline:
+  ja: |-
+    クリックやタップで実行される機能の実行、完了のトリガーには、ダウン・イベント（mousedown, touchdownなど）を使わず、アップ・イベント（mouseup, touchupなど）やクリック・イベント（clickなど）を使い、誤った操作を中断できるようにする。
+  en: |-
+    For functions that are executed by clicking or tapping, use up events (like mouseup, touchup) or click events (like click) instead of down events (like mousedown, touchdown) as triggers for execution and completion. This allows for the interruption of accidental operations.
 sc:
 - 2.5.2
-intent: |-
-  ポインティング・ディバイスやタッチUIでのタップの誤操作の影響を小さくする。
+intent:
+  ja: |-
+    ポインティング・ディバイスやタッチUIでのタップの誤操作の影響を小さくする。
 
-  -  意図しない場所でマウス・ボタンを押下してしまった場合に、ターゲットから外れた場所でボタンをリリースすることで、操作をキャンセルできる。
-  -  ドラッグ&ドロップの操作で誤った場所でマウス・ボタンを押下した場合、元の位置にマウス・ポインターを戻したうえでマウス・ボタンを放すと、ドラッグ&ドロップの操作をキャンセルできる。
-  -  タッチUIにおいて意図しない場所に触れてしまった場合に、ターゲットから外れた場所に指を移動して離すすることで、操作をキャンセルできる。
-  -  タッチUIでのドラッグ&ドロップの操作で誤った場所に触れた場合、元の位置に指を戻したうえで放すと、ドラッグ&ドロップの操作をキャンセルできる。
+    -  意図しない場所でマウス・ボタンを押下してしまった場合に、ターゲットから外れた場所でボタンをリリースすることで、操作をキャンセルできる。
+    -  ドラッグ&ドロップの操作で誤った場所でマウス・ボタンを押下した場合、元の位置にマウス・ポインターを戻したうえでマウス・ボタンを放すと、ドラッグ&ドロップの操作をキャンセルできる。
+    -  タッチUIにおいて意図しない場所に触れてしまった場合に、ターゲットから外れた場所に指を移動して離すすることで、操作をキャンセルできる。
+    -  タッチUIでのドラッグ&ドロップの操作で誤った場所に触れた場合、元の位置に指を戻したうえで放すと、ドラッグ&ドロップの操作をキャンセルできる。
+  en: |-
+    Minimize the impact of accidental actions with pointing devices and touch UI taps.
+
+    -  If you accidentally press the mouse button in an unintended place, you can cancel the operation by releasing the button outside of the target area.
+    -  In drag & drop operations, if the mouse button is pressed in the wrong place, moving the mouse pointer back to its original position and then releasing the button can cancel the drag & drop action.
+    -  In touch UI, if you accidentally touch an unintended area, moving your finger off the target and then releasing it can cancel the operation.
+    -  For drag & drop operations in touch UI, if you touch the wrong place, moving your finger back to the original position and then releasing it can cancel the drag & drop action.
 checks:
 - '0071'
 - '0081'

--- a/data/yaml/gl/link/color-only.yaml
+++ b/data/yaml/gl/link/color-only.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  クリッカブルであることを、色だけで表現しない。
+guideline:
+  ja: |-
+    クリッカブルであることを、色だけで表現しない。
+  en: |-
+    Do not express that something is clickable using color alone.
 sc:
 - 1.4.1
-intent: |-
-  視覚障害者や色弱者がリンクを認知できるようにする。
+intent:
+  ja: |-
+    視覚障害者や色弱者がリンクを認知できるようにする。
+  en: |-
+    Ensure that users with visual impairments or color vision deficiencies can perceive links.
 checks:
 - '0031'
 - '0051'

--- a/data/yaml/gl/link/consistent-text.yaml
+++ b/data/yaml/gl/link/consistent-text.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  同じ機能を実行するリンクは、サイト内で一貫性のあるリンク・テキストを付与する。
+guideline:
+  ja: |-
+    同じ機能を実行するリンクには、サイト内で一貫性のあるリンク・テキストを付与する。
+  en: |-
+    Provide consistent link text for links that perform the same function within a site.
 sc:
 - 3.2.4
-intent: |-
-  予測可能性を上げ、混乱を防ぐ。
+intent:
+  ja: |-
+    予測可能性を上げ、混乱を防ぐ。
+  en: |-
+    Increase predictability and prevent confusion.
 checks:
 - '0242'
 - '0262'

--- a/data/yaml/gl/link/tab-order.yaml
+++ b/data/yaml/gl/link/tab-order.yaml
@@ -6,12 +6,18 @@ title:
   en: Appropriate Focus Order
 platform:
 - web
-guideline: |-
-  Tab/Shift+Tabキーでフォーカスを移動させたとき、コンテンツの意味に合った適切な順序でフォーカスを移動させる。
+guideline:
+  ja: |-
+    Tab/Shift+Tabキーでフォーカスを移動させたとき、コンテンツの意味に合った適切な順序でフォーカスを移動させる。
+  en: |-
+    When moving focus using Tab/Shift+Tab keys, ensure that focus moves in an appropriate sequence that aligns with the content's meaning.
 sc:
 - 2.4.3
-intent: |-
-  スクリーン・リーダーなどの支援技術がコンテンツを正しく認識し、ユーザーに適切な形で提示できるようにする。
+intent:
+  ja: |-
+    スクリーン・リーダーなどの支援技術がコンテンツを正しく認識し、ユーザーに適切な形で提示できるようにする。
+  en: |-
+    Ensure that assistive technologies such as screen readers can correctly recognize content and present it to users appropriately.
 checks:
 - '0172'
 info:

--- a/data/yaml/gl/link/text.yaml
+++ b/data/yaml/gl/link/text.yaml
@@ -7,13 +7,20 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  リンク・テキスト（``a`` 要素の中身、アイコンのラベルなど）は、そのリンクの目的を判断できるものにする。
+guideline:
+  ja: |-
+    リンク・テキスト（``a`` 要素の中身、アイコンのラベルなど）は、そのリンクの目的を判断できるものにする。
+  en: |-
+    Make the link text (such as the content of an `a` element, labels for icons) such that the purpose of the link can be determined.
 sc:
 - 2.4.4
-intent: |-
-  *  リンク先を閲覧するかどうかの判断を容易にして、肢体不自由者の不必要な操作の抑制につなげる。
-  *  スクリーン・リーダーが提供するリンクの一覧機能を使う視覚障害者が、リンク先について容易に判断できるようにする。
+intent:
+  ja: |-
+    *  リンク先を閲覧するかどうかの判断を容易にして、肢体不自由者の不必要な操作の抑制につなげる。
+    *  スクリーン・リーダーが提供するリンクの一覧機能を使う視覚障害者が、リンク先について容易に判断できるようにする。
+  en: |-
+    *  Facilitate the decision-making process of whether to visit a link destination, thereby reducing unnecessary operations for individuals with physical disabilities.
+    *  Ensure that visually impaired individuals using screen readers' link listing functions can easily determine the link destination
 checks:
 - '0241'
 - '0261'

--- a/data/yaml/gl/login_session/continue.yaml
+++ b/data/yaml/gl/login_session/continue.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  ログイン・セッションが切れた場合は、再認証後でもデータを失うことなくユーザーが操作を継続できるようにする。
+guideline:
+  ja: |-
+    ログイン・セッションが切れた場合は、再認証後でもデータを失うことなくユーザーが操作を継続できるようにする。
+  en: |-
+    Ensure that users can continue their operation without losing data even after re-authentication when a login session has expired.
 sc:
 - 2.2.5
-intent: |-
-  コンテンツの読み取りや理解に時間がかかる場合や、入力操作などに時間がかかる場合にも問題なくサービスを利用できるようにする。
+intent:
+  ja: |-
+    コンテンツの読み取りや理解に時間がかかる場合や、入力操作などに時間がかかる場合にも問題なくサービスを利用できるようにする。
+  en: |-
+    Ensure that users can use services without problems even when it takes time to read or understand content or to perform input operations.
 checks:
 - '1381'
 info:

--- a/data/yaml/gl/login_session/timing.yaml
+++ b/data/yaml/gl/login_session/timing.yaml
@@ -7,19 +7,31 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  ログイン・セッションには有効期限を設けない。有効期限を設ける場合は、次に挙げる事項のうち、少なくとも1つを満たす。
+guideline:
+  ja: |-
+    ログイン・セッションには有効期限を設けない。有効期限を設ける場合は、次に挙げる事項のうち、少なくとも1つを満たす。
 
-  -  解除： ログイン時などに、ユーザーが有効期限の設定を解除することができる。又は、
-  -  調整： ログイン時などに、ユーザーが少なくともデフォルト設定の10倍を超える、有効期限の大幅な調整をすることができる。又は、
-  -  延長： 時間切れになる前にユーザーに警告し、かつ少なくとも20秒間の猶予をもって、例えば「スペースキーを押す」などの簡単な操作により、ユーザーが有効期限を10回以上延長することができる。又は、
-  -  必要不可欠な例外： 有効期限が必要不可欠なもので、有効期限を延長することがコンテンツの動作を無効にすることになる。又は、
-  -  20時間の例外： 有効期限が20時間よりも長い。
+    -  解除： ログイン時などに、ユーザーが有効期限の設定を解除することができる。又は、
+    -  調整： ログイン時などに、ユーザーが少なくともデフォルト設定の10倍を超える、有効期限の大幅な調整をすることができる。又は、
+    -  延長： 時間切れになる前にユーザーに警告し、かつ少なくとも20秒間の猶予をもって、例えば「スペースキーを押す」などの簡単な操作により、ユーザーが有効期限を10回以上延長することができる。又は、
+    -  必要不可欠な例外： 有効期限が必要不可欠なもので、有効期限を延長することがコンテンツの動作を無効にすることになる。又は、
+    -  20時間の例外： 有効期限が20時間よりも長い。
+  en: |-
+    Do not set an expiration date for login sessions. If you set an expiration date, meet at least one of the following criteria:
+
+    -  Removal: Users can remove the expiration date when they log in.
+    -  Adjustment: Users can adjust the expiration date by at least 10 times the default setting when they log in.
+    -  Extension: Users are warned before the expiration date and can extend the expiration date at least 20 seconds before the expiration date by performing a simple operation such as "pressing the space key".
+    -  Essential exceptions: The expiration date is essential, and extending the expiration date will disable the operation of the content.
+    -  20-hour exception: The expiration date is longer than 20 hours.
 sc:
 - 2.2.1
 - 2.2.3
-intent: |-
-  コンテンツの読み取りや理解に時間がかかる場合や、入力操作などに時間がかかる場合にも問題なくサービスを利用できるようにする。
+intent:
+  ja: |-
+    コンテンツの読み取りや理解に時間がかかる場合や、入力操作などに時間がかかる場合にも問題なくサービスを利用できるようにする。
+  en: |-
+    Ensure that users can use services without problems even when it takes time to read or understand content or to perform input operations.
 checks:
 - '1321'
 info:

--- a/data/yaml/gl/markup/component-implementation.yaml
+++ b/data/yaml/gl/markup/component-implementation.yaml
@@ -7,14 +7,22 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  リンクやボタン、フォーム・コントロールなど、ユーザーの操作を受け付けるUIコンポーネントは、なるべくHTMLの適切な要素、または使用している開発フレームワークの標準的なコンポーネントを用いて実装する。
+guideline:
+  ja: |-
+    リンクやボタン、フォーム・コントロールなど、ユーザーの操作を受け付けるUIコンポーネントは、なるべくHTMLの適切な要素、または使用している開発フレームワークの標準的なコンポーネントを用いて実装する。
+  en: |-
+    UI components that accept user input, such as links, buttons, and form controls, should be implemented using appropriate HTML elements or standard components of the development framework being used.
 sc:
 - 1.3.1
-intent: |-
-  -  スクリーン・リーダーなどの支援技術がコンテンツを正しく認識し、ユーザーに適切な形で提示できるようにする。
-  -  支援技術のユーザーが適切に操作することができるようにする。
-  -  キーボードによる操作を可能にする。
+intent:
+  ja: |-
+    -  スクリーン・リーダーなどの支援技術がコンテンツを正しく認識し、ユーザーに適切な形で提示できるようにする。
+    -  支援技術のユーザーが適切に操作することができるようにする。
+    -  キーボードによる操作を可能にする。
+  en: |-
+    -  Ensure that assistive technologies such as screen readers can correctly recognize content and present it to users in an appropriate manner.
+    -  Ensure that users of assistive technologies can operate content appropriately.
+    -  Ensure that content can be operated using a keyboard.
 checks:
 - '0553'
 - '0554'

--- a/data/yaml/gl/markup/component.yaml
+++ b/data/yaml/gl/markup/component.yaml
@@ -7,18 +7,30 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  ユーザーの操作を受け付けるUIコンポーネントは、以下を満たす実装をする。
+guideline:
+  ja: |-
+    ユーザーの操作を受け付けるUIコンポーネントは、以下を満たす実装をする。
 
-  -  支援技術を含むユーザー・エージェントが取得できる形で、適切にAccessibleNameとroleを定義する。
-  -  支援技術を含むユーザー・エージェントが、コンポーネントの状態、プロパティー、ユーザーが設定可能な値を設定でき、これらの変更を認知できるようにする。
+    -  支援技術を含むユーザー・エージェントが取得できる形で、適切にAccessibleNameとroleを定義する。
+    -  支援技術を含むユーザー・エージェントが、コンポーネントの状態、プロパティー、ユーザーが設定可能な値を設定でき、これらの変更を認知できるようにする。
+  en: |-
+    Implement UI components that receive user input in such a way that they meet the following criteria:
+
+    -  Define AccessibleName and role appropriately so that they can be acquired by user agents, including assistive technologies.
+    -  Ensure that user agents, including assistive technologies, can set and recognize changes in the component's state, properties, and user-configurable values.
 sc:
 - 4.1.2
-intent: |-
-  支援技術が、例えばJavaScriptで実装されているような独自のコンポーネントを問題なく扱えるようにする。
+intent:
+  ja: |-
+    支援技術が、例えばJavaScriptで実装されているような独自のコンポーネントを問題なく扱えるようにする。
 
-  -  例えば開閉できるメニュー、タブなど、標準的なHTMLだけでは実装できないようなコンポーネントについて、スクリーン・リーダーがそれはどのようなコンポーネントで、どのような状態にあのかを正確にユーザーに伝え、かつユーザーの操作を可能にする。
-  -  ユーザーの操作によってコンポーネントの状態が変化する場合は、その変化が認知できるようにする。
+    -  例えば開閉できるメニュー、タブなど、標準的なHTMLだけでは実装できないようなコンポーネントについて、スクリーン・リーダーがそれはどのようなコンポーネントで、どのような状態にあのかを正確にユーザーに伝え、かつユーザーの操作を可能にする。
+    -  ユーザーの操作によってコンポーネントの状態が変化する場合は、その変化が認知できるようにする。
+  en: |-
+    Ensure that assistive technologies can handle custom components, such as those implemented in JavaScript, without problems.
+
+    -  Ensure that screen readers can accurately convey to users what kind of component it is and what state it is in, and enable users to operate it, for components that cannot be implemented using only standard HTML, such as menus that can be opened and closed, and tabs.
+    -  Ensure that changes in the component's state can be recognized when the component's state changes due to user operations.
 checks:
 - '0581'
 - '0586'

--- a/data/yaml/gl/markup/semantics.yaml
+++ b/data/yaml/gl/markup/semantics.yaml
@@ -7,15 +7,24 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  静的なテキスト・コンテンツは、文書構造などのセマンティクスを適切に表現するHTMLの要素やコンポーネントで実装する。
+guideline:
+  ja: |-
+    静的なテキスト・コンテンツは、文書構造などのセマンティクスを適切に表現するHTMLの要素やコンポーネントで実装する。
+  en: |-
+    Implement static text content using HTML elements or components that accurately represent semantics such as document structure.
 sc:
 - 1.3.1
-intent: |-
-  スクリーン・リーダーなどの支援技術がコンテンツを正しく認識し、ユーザーに適切な形で提示できるようにする。
+intent:
+  ja: |-
+    スクリーン・リーダーなどの支援技術がコンテンツを正しく認識し、ユーザーに適切な形で提示できるようにする。
 
-  -  適切なマークアップにより、スクリーン・リーダーで見出しや箇条書きの項目を探しやすくなる。
-  -  スクリーン・リーダーなどの支援技術には、見出しやリンクの一覧表示機能など、適切なマークアップを前提に実装されている機能がある。
+    -  適切なマークアップにより、スクリーン・リーダーで見出しや箇条書きの項目を探しやすくなる。
+    -  スクリーン・リーダーなどの支援技術には、見出しやリンクの一覧表示機能など、適切なマークアップを前提に実装されている機能がある。
+  en: |-
+    Ensure that assistive technologies such as screen readers can correctly recognize content and present it to users in an appropriate manner.
+
+    -  Appropriate markup makes it easier for screen readers to find headings and list items.
+    -  Assistive technologies such as screen readers have functions such as displaying a list of headings and links, which are implemented based on appropriate markup.
 checks:
 - '0541'
 - '0542'

--- a/data/yaml/gl/markup/valid.yaml
+++ b/data/yaml/gl/markup/valid.yaml
@@ -6,14 +6,22 @@ title:
   en: Valid Markup
 platform:
 - web
-guideline: |-
-  文法的に正しい、仕様に準拠したマークアップを行う。
+guideline:
+  ja: |-
+    文法的に正しい、仕様に準拠したマークアップを行う。
+  en: |-
+    Use valid markup that conforms to specifications.
 sc:
 - 4.1.1
-intent: |-
-  スクリーン・リーダーなどの支援技術が、Webページを正確に解析できるようにする。
+intent:
+  ja: |-
+    スクリーン・リーダーなどの支援技術が、Webページを正確に解析できるようにする。
 
-  HTML要素の開始タグと終了タグが適切に記述されていること、適切な入れ子構造になっていることで、様々なユーザー・エージェントや支援技術が期待した動作をする。
+    HTML要素の開始タグと終了タグが適切に記述されていること、適切な入れ子構造になっていることで、様々なユーザー・エージェントや支援技術が期待した動作をする。
+  en: |-
+    Ensure that user agents and assistive technologies can accurately parse Web pages.
+
+    User agents and assistive technologies behave as expected when HTML elements are properly opened and closed and have appropriate nesting.
 checks:
 - '0571'
 info:

--- a/data/yaml/gl/multimedia/background-sound.yaml
+++ b/data/yaml/gl/multimedia/background-sound.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  映像がなく音声のみの収録済みコンテンツの場合で主たる発話音声があるとき、背景音がない、もしくは主たる発話音声に対して背景音の音量が少なくとも20db小さい状態にする。
+guideline:
+  ja: |-
+    映像がなく音声のみの収録済みコンテンツの場合で主たる発話音声があるとき、背景音がない、もしくは主たる発話音声に対して背景音の音量が少なくとも20db小さい状態にする。
+  en: |-
+    In the case of pre-recorded content that only contains audio and no video, when there is a primary spoken voice, ensure there is no background sound, or that the volume of the background sound is at least 20db lower than the primary spoken voice.
 sc:
 - 1.4.7
-intent: |-
-  音声コンテンツの内容を聞き取りやすいものにする。
+intent:
+  ja: |-
+    音声コンテンツの内容を聞き取りやすいものにする。
+  en: |-
+    Make the content of audio easily comprehensible.
 checks:
 - '1631'
 - '1651'

--- a/data/yaml/gl/multimedia/caption.yaml
+++ b/data/yaml/gl/multimedia/caption.yaml
@@ -7,15 +7,23 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  テキストの代替情報ではない音声・映像コンテンツにおいて、音声情報には、同期したキャプションを提供する。
+guideline:
+  ja: |-
+    テキストの代替情報ではない音声・映像コンテンツにおいて、音声情報には、同期したキャプションを提供する。
+  en: |-
+    In audio and video content that is not an alternative to text information, provide synchronized captions for the audio information.
 sc:
 - 1.2.2
 - 1.2.4
-intent: |-
-  音声情報を理解できなくてもサービスの利用が困難にならないようにする。
+intent:
+  ja: |-
+    音声情報を理解できなくてもサービスの利用が困難にならないようにする。
 
-  聴覚障害者が、音声コンテンツおよび動画コンテンツ内の音声を理解できるようにする。
+    聴覚障害者が、音声コンテンツおよび動画コンテンツ内の音声を理解できるようにする。
+  en: |-
+    Ensure that the service remains accessible even for those who cannot understand the audio information.
+
+    Make it possible for individuals with hearing impairments to understand the audio information in audio and video content.
 checks:
 - '1511'
 - '1531'

--- a/data/yaml/gl/multimedia/no-trap.yaml
+++ b/data/yaml/gl/multimedia/no-trap.yaml
@@ -6,12 +6,18 @@ title:
   en: Avoid Keyboard Traps
 platform:
 - web
-guideline: |-
-  音声/動画のプレイヤーをページに埋め込む場合、そのコンポーネントにフォーカスした状態から、Tabキー、矢印キー、Escキーなどで抜け出すことができるようにする。
+guideline:
+  ja: |-
+    音声/動画のプレイヤーをページに埋め込む場合、そのコンポーネントにフォーカスした状態から、Tabキー、矢印キー、Escキーなどで抜け出すことができるようにする。
+  en: |-
+    When embedding an audio/video player in a page, ensure that it is possible to move the focus away from the component by using the Tab key , arrow keys, or Esc key.
 sc:
 - 2.1.2
-intent: |-
-  キーボードのみを利用している場合に、ページ中の特定のコンポーネントがページの他の部分へのアクセスを阻害しないようにする。
+intent:
+  ja: |-
+    キーボードのみを利用している場合に、ページ中の特定のコンポーネントがページの他の部分へのアクセスを阻害しないようにする。
+  en: |-
+    Ensure that specific components on a page do not prevent access to other parts of the page when using only a keyboard.
 checks:
 - '0201'
 info:

--- a/data/yaml/gl/multimedia/operable.yaml
+++ b/data/yaml/gl/multimedia/operable.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  3秒以上の長さの音声を自動再生しない。
+guideline:
+  ja: |-
+    3秒以上の長さの音声を自動再生しない。
+  en: |-
+    Do not autoplay audio that is longer than 3 seconds.
 sc:
 - 1.4.2
-intent: |-
-  スクリーン・リーダーの音声出力を阻害しない。
+intent:
+  ja: |-
+    スクリーン・リーダーの音声出力を阻害しない。
+  en: |-
+    Do not interfere with the audio output of screen readers.
 checks:
 - '1421'
 - '1441'

--- a/data/yaml/gl/multimedia/pause-movement.yaml
+++ b/data/yaml/gl/multimedia/pause-movement.yaml
@@ -7,13 +7,20 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  自動的に開始し5秒以上継続する、アニメーションや動画のなどの視覚的な動きを伴うコンテンツを作らない。
-  そのようなコンテンツを作る場合は、ユーザーが一時停止、停止、または非表示にすることができるようにする。
+guideline:
+  ja: |-
+    自動的に開始し5秒以上継続する、アニメーションや動画のなどの視覚的な動きを伴うコンテンツを作らない。
+    そのようなコンテンツを作る場合は、ユーザーが一時停止、停止、または非表示にすることができるようにする。
+  en: |-
+    Do not create content that automatically starts and lasts for more than 5 seconds, such as animations and videos that include visual movement.
+    If you create such content, ensure that users can pause, stop, or hide it.
 sc:
 - 2.2.2
-intent: |-
-  ロービジョン者や認知障害者が、集中を阻害されないようにする。
+intent:
+  ja: |-
+    ロービジョン者や認知障害者が、集中を阻害されないようにする。
+  en: |-
+    Ensure that users with low vision or cognitive disabilities are not distracted.
 checks:
 - '1451'
 - '1471'

--- a/data/yaml/gl/multimedia/perceivable.yaml
+++ b/data/yaml/gl/multimedia/perceivable.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  音声・映像コンテンツの存在を認知できるようにする。
+guideline:
+  ja: |-
+    音声・映像コンテンツの存在を認知できるようにする。
+  en: |-
+    Ensure that users can perceive the presence of audio and video content.
 sc:
 - 1.1.1
-intent: |-
-  視覚障害者、聴覚障害者が音声や映像を含むコンテンツの存在を認知できるようにする。
+intent:
+  ja: |-
+    視覚障害者、聴覚障害者が音声や映像を含むコンテンツの存在を認知できるようにする。
+  en: |-
+    Ensure that users with visual or hearing impairments can perceive the presence of content that includes audio or video.
 checks:
 - '1411'
 info:

--- a/data/yaml/gl/multimedia/sign-language.yaml
+++ b/data/yaml/gl/multimedia/sign-language.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  収録済みコンテンツの音声情報には、同期した手話通訳を提供する。
+guideline:
+  ja: |-
+    収録済みコンテンツの音声情報には、同期した手話通訳を提供する。
+  en: |-
+    Provide synchronized sign language interpretation for the audio information in pre-recorded content.
 sc:
 - 1.2.6
-intent: |-
-  手話を主たる言語として使う聴覚障害者が、音声コンテンツまたは動画コンテンツ中の音声を理解できるようにする。
+intent:
+  ja: |-
+    手話を主たる言語として使う聴覚障害者が、音声コンテンツまたは動画コンテンツ中の音声を理解できるようにする。
+  en: |-
+    Make it possible for individuals with hearing impairments who use sign language as their primary language to understand the audio information in audio and video content.
 checks:
 - '1601'
 - '1621'

--- a/data/yaml/gl/multimedia/text-alternative.yaml
+++ b/data/yaml/gl/multimedia/text-alternative.yaml
@@ -7,15 +7,21 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  テキスト情報の代替情報として音声・映像コンテンツを用い、そのコンテンツがテキスト情報の代替であることを明示する。
+guideline:
+  ja: |-
+    テキスト情報の代替情報として音声・映像コンテンツを用い、そのコンテンツがテキスト情報の代替であることを明示する。
+  en: |-
+    Use audio and video content as an alternative to text information, and explicitly indicate that the content is an alternative to text information.
 sc:
 - 1.2.1
 - 1.2.2
 - 1.2.3
 - 1.2.4
-intent: |-
-  音声・映像コンテンツの利用ができないユーザーも支障なくコンテンツを利用できるようにする。
+intent:
+  ja: |-
+    音声・映像コンテンツの利用ができないユーザーも支障なくコンテンツを利用できるようにする。
+  en: |-
+    Ensure that users who cannot use audio and video content can use the content without any problems.
 checks:
 - '1481'
 - '1501'

--- a/data/yaml/gl/multimedia/transcript.yaml
+++ b/data/yaml/gl/multimedia/transcript.yaml
@@ -7,14 +7,22 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  テキストの代替情報ではない、映像がなく音声のみの収録済みコンテンツの場合は、書き起こしテキストを提供する。
+guideline:
+  ja: |-
+    テキストの代替情報ではない、映像がなく音声のみの収録済みコンテンツの場合は、書き起こしテキストを提供する。
+  en: |-
+    Provide a transcript for pre-recorded audio-only content that is not an alternative to text information.
 sc:
 - 1.2.1
-intent: |-
-  音声コンテンツを理解できなくてもサービスの利用が困難にならないようにする。
+intent:
+  ja: |-
+    音声コンテンツを理解できなくてもサービスの利用が困難にならないようにする。
 
-  聴覚障害者が音声のみのコンテンツを理解できるようにする。
+    聴覚障害者が音声のみのコンテンツを理解できるようにする。
+  en: |-
+    Ensure that the service remains accessible even for those who cannot understand the audio information.
+
+    Make it possible for individuals with hearing impairments to understand audio-only content.
 checks:
 - '1571'
 - '1591'

--- a/data/yaml/gl/multimedia/video-description-no-exception.yaml
+++ b/data/yaml/gl/multimedia/video-description-no-exception.yaml
@@ -7,15 +7,23 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  すべての音声・映像コンテンツにおいて、映像がある収録済みコンテンツの場合、映像の内容が分かるような同期した音声情報を提供する。
+guideline:
+  ja: |-
+    すべての音声・映像コンテンツにおいて、映像がある収録済みコンテンツの場合、映像の内容が分かるような同期した音声情報を提供する。
+  en: |-
+    In all audio and video content, for pre-recorded content with video, provide synchronized audio information that makes the content of the video understandable.
 sc:
 - 1.2.3
 - 1.2.5
-intent: |-
-  映像情報を理解できなくてもサービスの利用が困難にならないようにする。
+intent:
+  ja: |-
+    映像情報を理解できなくてもサービスの利用が困難にならないようにする。
 
-  視覚障害者が、映像コンテンツを理解できるようにする。
+    視覚障害者が、映像コンテンツを理解できるようにする。
+  en: |-
+    Ensure that the service remains accessible even for those who cannot understand the video information.
+
+    Make it possible for individuals with visual impairments to understand video content.
 checks:
 - '1542'
 - '1562'

--- a/data/yaml/gl/multimedia/video-description.yaml
+++ b/data/yaml/gl/multimedia/video-description.yaml
@@ -7,14 +7,22 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  テキストの代替情報ではない音声・映像コンテンツにおいて、映像がある収録済みコンテンツの場合、映像の内容が分かるような同期した音声情報、またはテキストによる説明を提供する。
+guideline:
+  ja: |-
+    テキストの代替情報ではない音声・映像コンテンツにおいて、映像がある収録済みコンテンツの場合、映像の内容が分かるような同期した音声情報、またはテキストによる説明を提供する。
+  en: |-
+    In audio and video content that is not a text alternative, for pre-recorded content with video, provide synchronized audio information or text descriptions that make the content of the video understandable.
 sc:
 - 1.2.3
-intent: |-
-  映像情報を理解できなくてもサービスの利用が困難にならないようにする。
+intent:
+  ja: |-
+    映像情報を理解できなくてもサービスの利用が困難にならないようにする。
 
-  視覚障害者が、映像コンテンツを理解できるようにする。
+    視覚障害者が、映像コンテンツを理解できるようにする。
+  en: |-
+    Ensure that the service remains accessible even for those who cannot understand the video information.
+
+    Make it possible for individuals with visual impairments to understand video content.
 checks:
 - '1541'
 - '1561'

--- a/data/yaml/gl/page/consistent-navigation.yaml
+++ b/data/yaml/gl/page/consistent-navigation.yaml
@@ -7,14 +7,22 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  ナビゲーション・メニューなど、複数のページに共通して用いられるコンポーネントは、すべてのページで同じ出現順序にし、コンポーネント内でのリンクの出現順序も同じにする。
+guideline:
+  ja: |-
+    ナビゲーション・メニューなど、複数のページに共通して用いられるコンポーネントは、すべてのページで同じ出現順序にし、コンポーネント内でのリンクの出現順序も同じにする。
+  en: |-
+    Ensure that components that are used across multiple pages, such as navigation menus, appear in the same sequence on every page, and that the sequence of links within each component is also the same.
 sc:
 - 3.2.3
-intent: |-
-  視覚障害者、認知障害者などが、ページの構成を容易に予測できるようにする。
+intent:
+  ja: |-
+    視覚障害者、認知障害者などが、ページの構成を容易に予測できるようにする。
 
-  -  共通部分に一貫性があれば、複数のページで毎回すべての表示内容を確認しなくても、推測に基づく操作がしやすくなる。
+    -  共通部分に一貫性があれば、複数のページで毎回すべての表示内容を確認しなくても、推測に基づく操作がしやすくなる。
+  en: |-
+    Ensure that users with visual or cognitive impairments can easily predict the structure of a page.
+
+    -  If there is consistency in the common parts, it is easier to perform operations based on prediction without having to check all the display contents every time on multiple pages.
 checks:
 - '0661'
 - '0781'

--- a/data/yaml/gl/page/headings.yaml
+++ b/data/yaml/gl/page/headings.yaml
@@ -7,15 +7,24 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  コンテンツを適切にセクション分けし、スクリーン・リーダーが認識できる形で見出しを付ける。
+guideline:
+  ja: |-
+    コンテンツを適切にセクション分けし、スクリーン・リーダーが認識できる形で見出しを付ける。
+  en: |-
+    Section content appropriately and provide headings in a form that screen readers can recognize.
 sc:
 - 2.4.10
-intent: |-
-  視覚障害者が、ページ内で目的のコンテンツを見つけやすくする。
+intent:
+  ja: |-
+    視覚障害者が、ページ内で目的のコンテンツを見つけやすくする。
 
-  -  多くのスクリーン・リーダーは、見出し間で移動する機能、見出しのリストを表示する機能がある。
-  -  適切な見出しが付けられていれば、見出しを追うことで斜め読みのような読み方ができる。
+    -  多くのスクリーン・リーダーは、見出し間で移動する機能、見出しのリストを表示する機能がある。
+    -  適切な見出しが付けられていれば、見出しを追うことで斜め読みのような読み方ができる。
+  en: |-
+    Make it easier for visually impaired individuals to find the content they need on a page.
+
+    *  Many screen readers have the ability to navigate between headings and display a list of headings.
+    *  If appropriate headings are provided, users can skim through the page content, by following the headings.
 checks:
 - '0541'
 - '0543'

--- a/data/yaml/gl/page/landmark.yaml
+++ b/data/yaml/gl/page/landmark.yaml
@@ -6,15 +6,24 @@ title:
   en: Indicate Regions That Compose a Page
 platform:
 - web
-guideline: |-
-  ページを構成する領域を示すマークアップをする。
+guideline:
+  ja: |-
+    ページを構成する領域を示すマークアップをする。
+  en: |-
+    Mark up regions that compose a page.
 sc:
 - 1.3.1
-intent: |-
-  スクリーン・リーダーなどの支援技術が、ページの構成を適切にユーザーに提示できるようにする。
+intent:
+  ja: |-
+    スクリーン・リーダーなどの支援技術が、ページの構成を適切にユーザーに提示できるようにする。
 
-  -  多くのスクリーン・リーダーには、ARIAランドマークで示される領域間を移動する機能がある。
-  -  スクリーン・リーダーのユーザーは、ページ内の目的の部分に容易に移動できる。
+    -  多くのスクリーン・リーダーには、ARIAランドマークで示される領域間を移動する機能がある。
+    -  スクリーン・リーダーのユーザーは、ページ内の目的の部分に容易に移動できる。
+  en: |-
+    Ensure that assistive technologies such as screen readers can appropriately present the page structure to users.
+
+    -  Many screen readers have the ability to move between regions indicated by ARIA landmarks.
+    -  Screen reader users can easily move to the desired part of the page.
 checks:
 - '0661'
 - '0671'

--- a/data/yaml/gl/page/location.yaml
+++ b/data/yaml/gl/page/location.yaml
@@ -7,14 +7,22 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  そのページが、サイト構造のどこに位置しているかが分かるようにする。
+guideline:
+  ja: |-
+    そのページが、サイト構造のどこに位置しているかが分かるようにする。
+  en: |-
+    Make it clear where the page is located within the site structure.
 sc:
 - 2.4.8
-intent: |-
-  ページ全体を一望することができない視覚障害者が、目的のページにアクセスしているかどうか判断できるようにする。
+intent:
+  ja: |-
+    ページ全体を一望することができない視覚障害者が、目的のページにアクセスしているかどうか判断できるようにする。
 
-  -  スクリーン・リーダーによっては、 ``aria-current`` 属性が付与されているメニュー・アイテムなどに「現在のページ」などという読み上げが追加される。
+    -  スクリーン・リーダーによっては、 ``aria-current`` 属性が付与されているメニュー・アイテムなどに「現在のページ」などという読み上げが追加される。
+  en: |-
+    Make it possible for visually impaired users who cannot view the entire page to determine whether they have accessed the page they want.
+
+    *  Some screen readers add the phrase "current page" to menu items that have the ``aria-current`` attribute.
 checks:
 - '0841'
 - '0851'

--- a/data/yaml/gl/page/markup-main.yaml
+++ b/data/yaml/gl/page/markup-main.yaml
@@ -6,15 +6,24 @@ title:
   en: Indicate the Beginning of the Main Content
 platform:
 - web
-guideline: |-
-  本文が始まる位置を示すマークアップをする。
+guideline:
+  ja: |-
+    本文が始まる位置を示すマークアップをする。
+  en: |-
+    Mark up the beginning of the main content.
 sc:
 - 2.4.1
-intent: |-
-  視覚障害者が、容易に本文の先頭を見つけられるようにする。
+intent:
+  ja: |-
+    視覚障害者が、容易に本文の先頭を見つけられるようにする。
 
-  -  多くのスクリーン・リーダーには、ARIAランドマークで示される領域間を移動する機能、見出し間を移動する機能がある。
-  -  スクリーン・リーダーのユーザーは、領域間を移動する機能で ``main`` 要素の先頭に移動したり、見出し間を移動する機能で本文の直前に移動したりして、迅速に本文を読み始めることができる。
+    -  多くのスクリーン・リーダーには、ARIAランドマークで示される領域間を移動する機能、見出し間を移動する機能がある。
+    -  スクリーン・リーダーのユーザーは、領域間を移動する機能で ``main`` 要素の先頭に移動したり、見出し間を移動する機能で本文の直前に移動したりして、迅速に本文を読み始めることができる。
+  en: |-
+    Ensure that visually impaired individuals can easily find the beginning of the main text.
+
+    *  Many screen readers have the capability to navigate between areas indicated by ARIA landmarks and between headings.
+    *  Users of screen readers can quickly start reading the main text by moving to the beginning of the ``main`` element using the region navigation feature, or to just before the main text using the heading navigation feature.
 checks:
 - '0672'
 - '0681'

--- a/data/yaml/gl/page/markup-order.yaml
+++ b/data/yaml/gl/page/markup-order.yaml
@@ -6,15 +6,24 @@ title:
   en: Appropriate Markup Order
 platform:
 - web
-guideline: |-
-  最初から順に読み進めた場合に、コンテンツの意味が正しく伝わるような順序でHTMLの各要素を記述する。
+guideline:
+  ja: |-
+    最初から順に読み進めた場合に、コンテンツの意味が正しく伝わるような順序でHTMLの各要素を記述する。
+  en: |-
+    Write HTML elements in an order that ensures the correct meaning of the content is conveyed when read through from the beginning.
 sc:
 - 1.3.2
-intent: |-
-  スクリーン・リーダーなどの支援技術のユーザーが、コンテンツを正しく理解できるようにする。
+intent:
+  ja: |-
+    スクリーン・リーダーなどの支援技術のユーザーが、コンテンツを正しく理解できるようにする。
 
-  -  画面上で近接して表示されているコンテンツは、HTMLソース中ても同様に近接して記述することで、スクリーン・リーダーのユーザーにも見つけやすく、認知しやすくなる。
-  -  CSSでレイアウトを制御しているような場合に注意が必要。
+    -  画面上で近接して表示されているコンテンツは、HTMLソース中ても同様に近接して記述することで、スクリーン・リーダーのユーザーにも見つけやすく、認知しやすくなる。
+    -  CSSでレイアウトを制御しているような場合に注意が必要。
+  en: |-
+    Ensure that users of assistive technologies, such as screen readers, can correctly understand the content.
+
+    *  Content that is displayed closely together on the screen should also be written closely together in the HTML source. This makes it easier for screen reader users to find and recognize the content.
+    *  Caution is needed in cases where the layout is controlled by CSS.
 checks:
 - '0711'
 info:

--- a/data/yaml/gl/page/orientation.yaml
+++ b/data/yaml/gl/page/orientation.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  コンテンツの性質上必要不可欠な場合を除いて、特定の画面方向（縦置き/横置き）での利用を強制しない。
+guideline:
+  ja: |-
+    コンテンツの性質上必要不可欠な場合を除いて、特定の画面方向（縦置き/横置き）での利用を強制しない。
+  en: |-
+    Do not force the use of a specific screen orientation (portrait/landscape) unless it is essential for the nature of the content.
 sc:
 - 1.3.4
-intent: |-
-  タブレットなどの端末を、特定の方向（縦置き/横置き）に固定して使う必要がある肢体不自由者などが、コンテンツを利用することを妨げない。
+intent:
+  ja: |-
+    タブレットなどの端末を、特定の方向（縦置き/横置き）に固定して使う必要がある肢体不自由者などが、コンテンツを利用することを妨げない。
+  en: |-
+    Ensure that content is accessible to individuals with physical disabilities, such as those who need to use devices like tablets in a fixed orientation (portrait/landscape).
 checks:
 - '0751'
 - '0771'

--- a/data/yaml/gl/page/redundant-navigation.yaml
+++ b/data/yaml/gl/page/redundant-navigation.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  そのページへの到達手段を複数提供する。ただし、そのページが何らかの手順の実行の過程や結果としてしか表示されない場合は除く。
+guideline:
+  ja: |-
+    そのページへの到達手段を複数提供する。ただし、そのページが何らかの手順の実行の過程や結果としてしか表示されない場合は除く。
+  en: |-
+    Provide multiple ways to reach that page. However, this does not apply if the page is displayed only as part of a process or as a result of performing certain procedures.
 sc:
 - 2.4.5
-intent: |-
-  利用環境や認知能力などの違いにかかわらず、そのページへのアクセスのしやすさを確保する。
+intent:
+  ja: |-
+    利用環境や認知能力の違いにかかわらず、そのページへのアクセスのしやすさを確保する。
+  en: |-
+    Ensure ease of access to that page, regardless of differences in usage environment, and cognitive abilities.
 checks:
 - '0811'
 info:

--- a/data/yaml/gl/page/title.yaml
+++ b/data/yaml/gl/page/title.yaml
@@ -6,15 +6,24 @@ title:
   en: Specify a Title
 platform:
 - web
-guideline: |-
-  ``title`` 要素に、ページの主題又は目的を説明したタイトルを 記述する。
+guideline:
+  ja: |-
+    ``title`` 要素に、ページの主題又は目的を説明したタイトルを 記述する。
+  en: |-
+    Write a title in the ``title`` element that describes the main subject or purpose of the page.
 sc:
 - 2.4.2
-intent: |-
-  ページ全体を一望することができない視覚障害者が、目的のページにアクセスしているかどうか判断できるようにする。
+intent:
+  ja: |-
+    ページ全体を一望することができない視覚障害者が、目的のページにアクセスしているかどうか判断できるようにする。
 
-  -  多くのスクリーン・リーダーにはタイトルバーの内容を簡単に確認できる機能がある。
-  -  多くのスクリーン・リーダーでは、複数のウィンドウを切り替える操作をする際タイトルバーの内容が読み上げられる。
+    -  多くのスクリーン・リーダーにはタイトルバーの内容を簡単に確認できる機能がある。
+    -  多くのスクリーン・リーダーでは、複数のウィンドウを切り替える操作をする際タイトルバーの内容が読み上げられる。
+  en: |-
+    Ensure that visually impaired individuals who cannot view the entire page at once can determine whether they have accessed the intended page.
+
+    *  Many screen readers have the capability to quickly check the contents of the title bar.
+    *  Many screen readers read the contents of the title bar when switching between multiple windows.
 checks:
 - '0631'
 - '0651'

--- a/data/yaml/gl/text/color-only.yaml
+++ b/data/yaml/gl/text/color-only.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  強調、引用など、何らかの意図を文字色を変えることによって表現している場合、書体など他の視覚的な要素も併せて用い、色が判別できなくてもその意味を理解できるようにする。
+guideline:
+  ja: |-
+    強調、引用など、何らかの意図を文字色を変えることによって表現している場合、書体など他の視覚的な要素も併せて用い、色が判別できなくてもその意味を理解できるようにする。
+  en: |-
+    When expressing emphasis, quotation, etc. by changing the text color, also use other visual elements like font styles to ensure that the meaning can be understood even if the color cannot be discerned.
 sc:
 - 1.4.1
-intent: |-
-  視覚障害者や色弱者がコンテンツを利用できるようにする。
+intent:
+  ja: |-
+    視覚障害者や色弱者がコンテンツを利用できるようにする。
+  en: |-
+    Ensure that users with visual impairments or color vision deficiencies can use content.
 checks:
 - '0031'
 - '0051'

--- a/data/yaml/gl/text/component-lang.yaml
+++ b/data/yaml/gl/text/component-lang.yaml
@@ -3,16 +3,22 @@ sortKey: 1426
 category: text
 title:
   ja: テキストを表示するUIコンポーネントの言語の明示
-  en: Explicit Specify the Language for Text-Displaying UI Components
+  en: Explicitly Specify the Language for Text-Displaying UI Components
 platform:
 - web
 - mobile
-guideline: |-
-  テキストを表示するUIコンポーネントにおいて、言語やロケールを指定できる場合は、適切なものを指定する。
+guideline:
+  ja: |-
+    テキストを表示するUIコンポーネントにおいて、言語やロケールを指定できる場合は、適切なものを指定する。
+  en: |-
+    For UI components that display text, specify the appropriate language or locale if possible.
 sc:
 - 3.1.2
-intent: |-
-  音声/点字出力などが適切に行われるようにする。
+intent:
+  ja: |-
+    音声/点字出力などが適切に行われるようにする。
+  en: |-
+    Ensure that speech and braille output is performed appropriately.
 checks:
 - '0912'
 - '0922'

--- a/data/yaml/gl/text/contrast.yaml
+++ b/data/yaml/gl/text/contrast.yaml
@@ -6,22 +6,37 @@ title:
   en: Ensure Sufficient Contrast Ratio
 platform:
 - web
-guideline: |-
-  文字色と背景色に十分なコントラストを確保する。
+guideline:
+  ja: |-
+    文字色と背景色に十分なコントラストを確保する。
 
-  -  テキストの文字サイズが29px（22pt）以上の場合： 3:1以上
-  -  テキストの文字サイズが24px（18pt）以上で太字の場合： 3:1以上
-  -  その他の場合： 4.5:1以上
+    -  テキストの文字サイズが29px（22pt）以上の場合： 3:1以上
+    -  テキストの文字サイズが24px（18pt）以上で太字の場合： 3:1以上
+    -  その他の場合： 4.5:1以上
 
-  注：freeeのプロダクトやWebサイトにおいては、主に日本語が用いられているため、Understanding WCAG 2.1 [#]_ の日本語訳 [#]_ 中の訳注で示されている基準を用いています。
+    注：freeeのプロダクトやWebサイトにおいては、主に日本語が用いられているため、Understanding WCAG 2.1 [#]_ の日本語訳 [#]_ 中の訳注で示されている基準を用いています。
 
-  .. [#] `Understanding Success Criterion 1.4.3: Contrast (Minimum) <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html>`_
-  .. [#] `達成基準 1.4.3: コントラスト (最低限)を理解する <https://waic.jp/translations/WCAG21/Understanding/contrast-minimum.html>`_
+    .. [#] `Understanding Success Criterion 1.4.3: Contrast (Minimum) <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html>`_
+    .. [#] `達成基準 1.4.3: コントラスト (最低限)を理解する <https://waic.jp/translations/WCAG21/Understanding/contrast-minimum.html>`_
+  en: |-
+    Ensure sufficient contrast between the colors of text and their background colors.
+
+    -  For text size 29px (22pt) or larger: a contrast ratio of at least 3:1.
+    -  For bold text 24px (18pt) or larger: a contrast ratio of at least 3:1.
+    -  In other cases: a contrast ratio of at least 4.5:1.
+
+    Note: In freee products and websites, Japanese is mainly used, so the criteria indicated in the translation notes in Understanding WCAG 2.1 [#]_ [#]_ are used.
+
+    .. [#] `Understanding Success Criterion 1.4.3: Contrast (Minimum) <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html>`_
+    .. [#] `達成基準 1.4.3: コントラスト (最低限)を理解する <https://waic.jp/translations/WCAG21/Understanding/contrast-minimum.html>`_
 sc:
 - 1.4.3
 - 1.4.6
-intent: |-
-  ロービジョン者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    ロービジョン者が、コンテンツを利用できるようにする。
+  en: |-
+    Ensure that users with low vision can use the content.
 checks:
 - '0002'
 - '0021'

--- a/data/yaml/gl/text/customize.yaml
+++ b/data/yaml/gl/text/customize.yaml
@@ -6,12 +6,18 @@ title:
   en: Customization of Text Display
 platform:
 - web
-guideline: |-
-  ユーザーがline-heightを1.5em以上、段落に続く空白を2em以上、letter-spacingを0.12em以上に変更し、その他のプロパティーを一切変更していない状況において、コンテンツおよび機能に損失が生じないようにする。
+guideline:
+  ja: |-
+    ユーザーが ``line-height`` を1.5em以上、段落に続く空白を2em以上、 ``letter-spacing`` を0.12em以上に変更し、その他のプロパティーを一切変更していない状況において、コンテンツおよび機能に損失が生じないようにする。
+  en: |-
+    Ensure that there is no loss of content or functionality when the user changes the ``line-height`` to 1.5em or more, the space following a paragraph to 2em or more, and the ``letter-spacing`` to 0.12em or more, and does not change any other properties.
 sc:
 - 1.4.12
-intent: |-
-  ロービジョン者が、問題なくコンテンツを利用できるようにする。
+intent:
+  ja: |-
+    ロービジョン者が、問題なくコンテンツを利用できるようにする。
+  en: |-
+    Ensure that users with low vision can use content without problems.
 checks:
 - '0891'
 info:

--- a/data/yaml/gl/text/enlarge-settings.yaml
+++ b/data/yaml/gl/text/enlarge-settings.yaml
@@ -6,12 +6,18 @@ title:
   en: Change Text Size Settings
 platform:
 - web
-guideline: |-
-  ブラウザーの文字サイズ設定を200パーセントにしても、コンテンツの理解や機能が損なわれるような表示の崩れが発生せず、適切に拡大表示されるようにする。
+guideline:
+  ja: |-
+    ブラウザーの文字サイズ設定を200パーセントにしても、コンテンツの理解や機能が損なわれるような表示の崩れが発生せず、適切に拡大表示されるようにする。
+  en: |-
+    Ensure that the content is appropriately magnified and remains comprehensible and functional, without any disruption in display, even when the browser's text size setting is increased to 200 percent.
 sc:
 - 1.4.4
-intent: |-
-  ロービジョン者の中には、ブラウザーのズーム機能ではなく、文字サイズの変更機能を利用して、コンテンツを拡大表示する人もいる。このようなユーザーの利用に支障が出ないようにする。
+intent:
+  ja: |-
+    ロービジョン者の中には、ブラウザーのズーム機能ではなく、文字サイズの変更機能を利用して、コンテンツを拡大表示する人もいる。このようなユーザーの利用に支障が出ないようにする。
+  en: |-
+    Some individuals with low vision use the text size changing function, rather than the browser's zoom feature, to enlarge content. Ensure that this does not hinder the usage for such users.
 checks:
 - '0311'
 - '0323'

--- a/data/yaml/gl/text/heading-label.yaml
+++ b/data/yaml/gl/text/heading-label.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  主題又は目的を説明する見出しを付ける。
+guideline:
+  ja: |-
+    主題又は目的を説明する見出しを付ける。
+  en: |-
+    Provide headings that describe the topic or purpose.
 sc:
 - 2.4.6
-intent: |-
-  視覚障害者が、ページ内で目的のコンテンツを見つけやすくする。
+intent:
+  ja: |-
+    視覚障害者が、ページ内で目的のコンテンツを見つけやすくする。
+  en: |-
+    Ensure that users with visual impairments can easily find the content they are looking for within a page.
 checks:
 - '0271'
 info:

--- a/data/yaml/gl/text/mobile-contrast.yaml
+++ b/data/yaml/gl/text/mobile-contrast.yaml
@@ -6,22 +6,37 @@ title:
   en: Ensure Sufficient Contrast Ratio on Mobile OS
 platform:
 - mobile
-guideline: |-
-  文字色と背景色に十分なコントラストを確保する。
+guideline:
+  ja: |-
+    文字色と背景色に十分なコントラストを確保する。
 
-  -  テキストの文字サイズが24px（18pt）以上の場合：3:1以上
-  -  テキストの文字サイズが19px（14pt）以上で太字の場合：3:1以上
-  -  その他の場合： 4.5:1以上
+    -  テキストの文字サイズが24px（18pt）以上の場合：3:1以上
+    -  テキストの文字サイズが19px（14pt）以上で太字の場合：3:1以上
+    -  その他の場合： 4.5:1以上
 
-  注：モバイル・アプリケーションにおいては、デスクトップのWebと比較して文字サイズの変更方法が広く知られていると推測されること、各プラットフォームのガイドライン [#]_ [#]_ においてもWCAG 2.1に準じた基準を用いていることから、上記の基準としています。
+    注：モバイル・アプリケーションにおいては、デスクトップのWebと比較して文字サイズの変更方法が広く知られていると推測されること、各プラットフォームのガイドライン [#]_ [#]_ においてもWCAG 2.1に準じた基準を用いていることから、上記の基準としています。
 
-  .. [#] `アクセシビリティ | Apple Developer Documentation <https://developer.apple.com/jp/design/human-interface-guidelines/accessibility>`_
-  .. [#] `Accessibility – Material Design 3 <https://m3.material.io/foundations/accessible-design/patterns#f72f3851-5184-4132-b871-bc8224e062e2>`_
+    .. [#] `アクセシビリティ | Apple Developer Documentation <https://developer.apple.com/jp/design/human-interface-guidelines/accessibility>`_
+    .. [#] `Accessibility – Material Design 3 <https://m3.material.io/foundations/accessible-design/patterns#f72f3851-5184-4132-b871-bc8224e062e2>`_
+  en: |-
+    Ensure sufficient contrast between the colors of text and their background colors.
+
+    -  For text size 24px (18pt) or larger: a contrast ratio of at least 3:1.
+    -  For bold text 19px (14pt) or larger: a contrast ratio of at least 3:1.
+    -  In other cases: a contrast ratio of at least 4.5:1.
+
+    Note: In mobile applications, it is assumed that methods for changing text size are more widely known compared to desktop web, and the guidelines of each platform [#]_ [#]_ also use standards in line with WCAG 2.1, hence the above criteria are set.
+
+    .. [#] `Accessibility | Apple Developer Documentation <https://developer.apple.com/design/human-interface-guidelines/accessibility>`_
+    .. [#] `Accessibility – Material Design 3 <https://m3.material.io/foundations/accessible-design/patterns#f72f3851-5184-4132-b871-bc8224e062e2>`_
 sc:
 - 1.4.3
 - 1.4.6
-intent: |-
-  ロービジョン者が、コンテンツを利用できるようにする。
+intent:
+  ja: |-
+    ロービジョン者が、コンテンツを利用できるようにする。
+  en: |-
+    Ensure that users with low vision can use the content.
 checks:
 - '0003'
 - '0021'

--- a/data/yaml/gl/text/mobile-enlarge-settings.yaml
+++ b/data/yaml/gl/text/mobile-enlarge-settings.yaml
@@ -6,12 +6,18 @@ title:
   en: Change Text Size Settings of Mobile OS
 platform:
 - mobile
-guideline: |-
-  モバイルOSの設定で文字サイズを最大にしても、コンテンツの理解や機能が損なわれるような表示の崩れが発生せず、適切に拡大表示されるようにする。
+guideline:
+  ja: |-
+    モバイルOSの設定で文字サイズを最大にしても、コンテンツの理解や機能が損なわれるような表示の崩れが発生せず、適切に拡大表示されるようにする。
+  en: |-
+    Ensure that the content is appropriately magnified and remains comprehensible and functional, without any disruption in display, even when the text size setting of the mobile OS is increased to the maximum.
 sc:
 - 1.4.4
-intent: |-
-  ロービジョン者が、OSの文字サイズ変更設定で拡大表示を行う設定をした際、実際に拡大表示が行われるかどうかにかかわらず、表示が崩れるなど、コンテンツの利用に支障がでることがないようにする。
+intent:
+  ja: |-
+    ロービジョン者が、OSの文字サイズ変更設定で拡大表示を行う設定をした際、適切に拡大表示が行われ、表示が崩れるなど、コンテンツの利用に支障がでることがないようにする。
+  en: |-
+    Ensure that for individuals with low vision, when the text size enlargement setting is enabled in the OS, the content is appropriately magnified and there are no disruptions in usage, such as display distortion.
 checks:
 - '0325'
 - '0326'

--- a/data/yaml/gl/text/multiple-modality.yaml
+++ b/data/yaml/gl/text/multiple-modality.yaml
@@ -7,12 +7,18 @@ title:
 platform:
 - web
 - mobile
-guideline: |-
-  特定の感覚だけを前提とした表現を用いない。
+guideline:
+  ja: |-
+    特定の感覚だけを前提とした表現を用いない。
+  en: |-
+    Do not use expressions that rely solely on a specific sense.
 sc:
 - 1.3.3
-intent: |-
-  視覚障害者、色弱者がコンテンツを利用できるようにする。
+intent:
+  ja: |-
+    視覚障害者、色弱者がコンテンツを利用できるようにする。
+  en: |-
+    Ensure that users with visual impairments and color vision deficiencies can use content.
 checks:
 - '0032'
 info:

--- a/data/yaml/gl/text/page-lang.yaml
+++ b/data/yaml/gl/text/page-lang.yaml
@@ -6,12 +6,18 @@ title:
   en: Specify the Primary Language of the Page
 platform:
 - web
-guideline: |-
-  ``html`` 要素に適切にlang属性を指定する。
+guideline:
+  ja: |-
+    ``html`` 要素に適切にlang属性を指定する。
+  en: |-
+    Specify the ``lang`` attribute for the ``html`` element appropriately.
 sc:
 - 3.1.1
-intent: |-
-  音声/点字出力などが適切に行われるようにする。
+intent:
+  ja: |-
+    音声/点字出力などが適切に行われるようにする。
+  en: |-
+    Ensure that speech and braille output is performed appropriately.
 checks:
 - '0611'
 - '0621'

--- a/data/yaml/gl/text/phrase-lang.yaml
+++ b/data/yaml/gl/text/phrase-lang.yaml
@@ -6,12 +6,18 @@ title:
   en: Explicitly Indicate Partially Used Languages
 platform:
 - web
-guideline: |-
-  段落単位など、比較的長いテキストの言語が ``html`` 要素の ``lang`` 属性で指定したものと異なる場合は、その部分に対して適切に ``lang`` 属性を指定する。
+guideline:
+  ja: |-
+    段落単位など、比較的長いテキストの言語が ``html`` 要素の ``lang`` 属性で指定したものと異なる場合は、その部分に対して適切に ``lang`` 属性を指定する。
+  en: |-
+    If the language of a relatively long text, such as a paragraph, is different from the one specified by the ``lang`` attribute of the ``html`` element, specify the ``lang`` attribute appropriately for that part.
 sc:
 - 3.1.2
-intent: |-
-  音声/点字出力などが適切に行われるようにする。
+intent:
+  ja: |-
+    音声/点字出力などが適切に行われるようにする。
+  en: |-
+    Ensure that speech and braille output is performed appropriately.
 checks:
 - '0911'
 - '0921'

--- a/data/yaml/gl/text/zoom-reflow.yaml
+++ b/data/yaml/gl/text/zoom-reflow.yaml
@@ -6,12 +6,18 @@ title:
   en: 400 Percent Magnification Using Zoom Function
 platform:
 - web
-guideline: |-
-  ブラウザーのズーム機能を用いて400パーセントの拡大表示をしたときでも、横書きのコンテンツのように縦スクロールを前提としたコンテンツては横スクロールが、縦書きのコンテンツのように横スクロールを前提としたコンテンツでは縦スクロールが必要にならないようにする。
+guideline:
+  ja: |-
+    ブラウザーのズーム機能を用いて400パーセントの拡大表示をしたときでも、横書きのコンテンツのように縦スクロールを前提としたコンテンツては横スクロールが、縦書きのコンテンツのように横スクロールを前提としたコンテンツでは縦スクロールが必要にならないようにする。
+  en: |-
+    Ensure that even when using the browser's zoom function to magnify to 400 percent, horizontal scrolling is not required for content designed for vertical scrolling like horizontally written content, and vertical scrolling is not required for content designed for horizontal scrolling like vertically written content.
 sc:
 - 1.4.10
-intent: |-
-  ロービジョン者が、ズーム機能で拡大表示しても問題なくコンテンツを利用できるようにする。
+intent:
+  ja: |-
+    ロービジョン者が、ズーム機能で拡大表示しても問題なくコンテンツを利用できるようにする。
+  en: |-
+    Ensure that individuals with low vision can use the content without issues, even when magnifying it with the zoom function.
 checks:
 - '0322'
 info:

--- a/data/yaml/gl/text/zoom.yaml
+++ b/data/yaml/gl/text/zoom.yaml
@@ -6,12 +6,18 @@ title:
   en: 200 Percent Magnification Using Zoom Function
 platform:
 - web
-guideline: |-
-  コンテンツや機能を損なうことなく、ブラウザーのズーム機能で200パーセントまで拡大できるようにする。
+guideline:
+  ja: |-
+    コンテンツや機能を損なうことなく、ブラウザーのズーム機能で200パーセントまで拡大できるようにする。
+  en: |-
+    Ensure that content and functions can be magnified to 200 percent using the browser's zoom function without loss of content or functionality.
 sc:
 - 1.4.4
-intent: |-
-  ロービジョン者が、問題なくコンテンツを利用できるようにする。
+intent:
+  ja: |-
+    ロービジョン者が、問題なくコンテンツを利用できるようにする。
+  en: |-
+    Ensure that users with low vision can use content without problems.
 checks:
 - '0321'
 info:

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -360,10 +360,10 @@ def main():
         category_pages[gl['category']]['dependency'].append(gl['src_path'])
         gl_str = {
             'title': gl['title'][LANG],
-            'intent': gl['intent'],
+            'intent': gl['intent'][LANG],
             'id': gl['id'],
             'platform': '、'.join(list(map(lambda item: PLATFORM_NAMES[item], gl['platform']))),
-            'guideline': gl['guideline']
+            'guideline': gl['guideline'][LANG]
         }
 
         if 'info' in gl:


### PR DESCRIPTION
- ガイドライン項目のスキーマで、本文と意図の項を多言語を前提にするように変更
- ガイドライン項目の本文意図を英訳
- yaml2rst.py: ガイドライン項目の本文と意図が多言語フィールドになったことに対応
