### PR TITLE
yaml2rst.pyのリファクタリング

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ source/inc/*
 source/faq/*
 .DS_Store
 /incfiles.mk
+__pycache__/

--- a/data/json/wcag-sc.json
+++ b/data/json/wcag-sc.json
@@ -1,5 +1,6 @@
 {
   "1.1.1": {
+    "id": "1.1.1",
     "sortKey": "10101",
     "en": {
       "title": "Non-text Content",
@@ -13,6 +14,7 @@
     "localPriority": "A"
   },
   "1.2.1": {
+    "id": "1.2.1",
     "sortKey": "10201",
     "en": {
       "title": "Audio-only and Video-only (Prerecorded)",
@@ -26,6 +28,7 @@
     "localPriority": "A"
   },
   "1.2.2": {
+    "id": "1.2.2",
     "sortKey": "10202",
     "en": {
       "title": "Captions (Prerecorded)",
@@ -39,6 +42,7 @@
     "localPriority": "A"
   },
   "1.2.3": {
+    "id": "1.2.3",
     "sortKey": "10203",
     "en": {
       "title": "Audio Description or Media Alternative (Prerecorded)",
@@ -52,6 +56,7 @@
     "localPriority": "A"
   },
   "1.2.4": {
+    "id": "1.2.4",
     "sortKey": "10204",
     "en": {
       "title": "Captions (Live)",
@@ -65,6 +70,7 @@
     "localPriority": "AA"
   },
   "1.2.5": {
+    "id": "1.2.5",
     "sortKey": "10205",
     "en": {
       "title": "Audio Description (Prerecorded)",
@@ -78,6 +84,7 @@
     "localPriority": "AA"
   },
   "1.2.6": {
+    "id": "1.2.6",
     "sortKey": "10206",
     "en": {
       "title": "Sign Language (Prerecorded)",
@@ -91,6 +98,7 @@
     "localPriority": "AA"
   },
   "1.2.7": {
+    "id": "1.2.7",
     "sortKey": "10207",
     "en": {
       "title": "Extended Audio Description (Prerecorded)",
@@ -104,6 +112,7 @@
     "localPriority": "AAA"
   },
   "1.2.8": {
+    "id": "1.2.8",
     "sortKey": "10208",
     "en": {
       "title": "Media Alternative (Prerecorded)",
@@ -117,6 +126,7 @@
     "localPriority": "AAA"
   },
   "1.2.9": {
+    "id": "1.2.9",
     "sortKey": "10209",
     "en": {
       "title": "Audio-only (Live)",
@@ -130,6 +140,7 @@
     "localPriority": "AAA"
   },
   "1.3.1": {
+    "id": "1.3.1",
     "sortKey": "10301",
     "en": {
       "title": "Info and Relationships",
@@ -143,6 +154,7 @@
     "localPriority": "A"
   },
   "1.3.2": {
+    "id": "1.3.2",
     "sortKey": "10302",
     "en": {
       "title": "Meaningful Sequence",
@@ -156,6 +168,7 @@
     "localPriority": "A"
   },
   "1.3.3": {
+    "id": "1.3.3",
     "sortKey": "10303",
     "en": {
       "title": "Sensory Characteristics",
@@ -169,6 +182,7 @@
     "localPriority": "A"
   },
   "1.3.4": {
+    "id": "1.3.4",
     "sortKey": "10304",
     "en": {
       "title": "Orientation",
@@ -182,6 +196,7 @@
     "localPriority": "A"
   },
   "1.3.5": {
+    "id": "1.3.5",
     "sortKey": "10305",
     "en": {
       "title": "Identify Input Purpose",
@@ -195,6 +210,7 @@
     "localPriority": "AAA"
   },
   "1.3.6": {
+    "id": "1.3.6",
     "sortKey": "10306",
     "en": {
       "title": "Identify Purpose",
@@ -208,6 +224,7 @@
     "localPriority": "AAA"
   },
   "1.4.1": {
+    "id": "1.4.1",
     "sortKey": "10401",
     "en": {
       "title": "Use of Color",
@@ -221,6 +238,7 @@
     "localPriority": "A"
   },
   "1.4.2": {
+    "id": "1.4.2",
     "sortKey": "10402",
     "en": {
       "title": "Audio Control",
@@ -234,6 +252,7 @@
     "localPriority": "A"
   },
   "1.4.3": {
+    "id": "1.4.3",
     "sortKey": "10403",
     "en": {
       "title": "Contrast (Minimum)",
@@ -247,6 +266,7 @@
     "localPriority": "A"
   },
   "1.4.4": {
+    "id": "1.4.4",
     "sortKey": "10404",
     "en": {
       "title": "Resize text",
@@ -260,6 +280,7 @@
     "localPriority": "A"
   },
   "1.4.5": {
+    "id": "1.4.5",
     "sortKey": "10405",
     "en": {
       "title": "Images of Text",
@@ -273,6 +294,7 @@
     "localPriority": "AA"
   },
   "1.4.6": {
+    "id": "1.4.6",
     "sortKey": "10406",
     "en": {
       "title": "Contrast (Enhanced)",
@@ -286,6 +308,7 @@
     "localPriority": "AA"
   },
   "1.4.7": {
+    "id": "1.4.7",
     "sortKey": "10407",
     "en": {
       "title": "Low or No Background Audio",
@@ -299,6 +322,7 @@
     "localPriority": "AA"
   },
   "1.4.8": {
+    "id": "1.4.8",
     "sortKey": "10408",
     "en": {
       "title": "Visual Presentation",
@@ -312,6 +336,7 @@
     "localPriority": "AAA"
   },
   "1.4.9": {
+    "id": "1.4.9",
     "sortKey": "10409",
     "en": {
       "title": "Images of Text (No Exception)",
@@ -325,6 +350,7 @@
     "localPriority": "AA"
   },
   "1.4.10": {
+    "id": "1.4.10",
     "sortKey": "10410",
     "en": {
       "title": "Reflow",
@@ -338,6 +364,7 @@
     "localPriority": "AA"
   },
   "1.4.11": {
+    "id": "1.4.11",
     "sortKey": "10411",
     "en": {
       "title": "Non-text Contrast",
@@ -351,6 +378,7 @@
     "localPriority": "A"
   },
   "1.4.12": {
+    "id": "1.4.12",
     "sortKey": "10412",
     "en": {
       "title": "Text Spacing",
@@ -364,6 +392,7 @@
     "localPriority": "A"
   },
   "1.4.13": {
+    "id": "1.4.13",
     "sortKey": "10413",
     "en": {
       "title": "Content on Hover or Focus",
@@ -377,6 +406,7 @@
     "localPriority": "一部A"
   },
   "2.1.1": {
+    "id": "2.1.1",
     "sortKey": "20101",
     "en": {
       "title": "Keyboard",
@@ -390,6 +420,7 @@
     "localPriority": "A"
   },
   "2.1.2": {
+    "id": "2.1.2",
     "sortKey": "20102",
     "en": {
       "title": "No Keyboard Trap",
@@ -403,6 +434,7 @@
     "localPriority": "A"
   },
   "2.1.3": {
+    "id": "2.1.3",
     "sortKey": "20103",
     "en": {
       "title": "Keyboard (No Exception)",
@@ -416,6 +448,7 @@
     "localPriority": "A"
   },
   "2.1.4": {
+    "id": "2.1.4",
     "sortKey": "20104",
     "en": {
       "title": "Character Key Shortcuts",
@@ -429,6 +462,7 @@
     "localPriority": "A"
   },
   "2.2.1": {
+    "id": "2.2.1",
     "sortKey": "20201",
     "en": {
       "title": "Timing Adjustable",
@@ -442,6 +476,7 @@
     "localPriority": "A"
   },
   "2.2.2": {
+    "id": "2.2.2",
     "sortKey": "20202",
     "en": {
       "title": "Pause, Stop, Hide",
@@ -455,6 +490,7 @@
     "localPriority": "A"
   },
   "2.2.3": {
+    "id": "2.2.3",
     "sortKey": "20203",
     "en": {
       "title": "No Timing",
@@ -468,6 +504,7 @@
     "localPriority": "AA"
   },
   "2.2.4": {
+    "id": "2.2.4",
     "sortKey": "20204",
     "en": {
       "title": "Interruptions",
@@ -481,6 +518,7 @@
     "localPriority": "AA"
   },
   "2.2.5": {
+    "id": "2.2.5",
     "sortKey": "20205",
     "en": {
       "title": "Re-authenticating",
@@ -494,6 +532,7 @@
     "localPriority": "AA"
   },
   "2.2.6": {
+    "id": "2.2.6",
     "sortKey": "20206",
     "en": {
       "title": "Timeouts",
@@ -507,6 +546,7 @@
     "localPriority": "AAA"
   },
   "2.3.1": {
+    "id": "2.3.1",
     "sortKey": "20301",
     "en": {
       "title": "Three Flashes or Below Threshold",
@@ -520,6 +560,7 @@
     "localPriority": "A"
   },
   "2.3.2": {
+    "id": "2.3.2",
     "sortKey": "20302",
     "en": {
       "title": "Three Flashes",
@@ -533,6 +574,7 @@
     "localPriority": "A"
   },
   "2.3.3": {
+    "id": "2.3.3",
     "sortKey": "20303",
     "en": {
       "title": "Animation from Interactions",
@@ -546,6 +588,7 @@
     "localPriority": "AAA"
   },
   "2.4.1": {
+    "id": "2.4.1",
     "sortKey": "20401",
     "en": {
       "title": "Bypass Blocks",
@@ -559,6 +602,7 @@
     "localPriority": "A"
   },
   "2.4.2": {
+    "id": "2.4.2",
     "sortKey": "20402",
     "en": {
       "title": "Page Titled",
@@ -572,6 +616,7 @@
     "localPriority": "A"
   },
   "2.4.3": {
+    "id": "2.4.3",
     "sortKey": "20403",
     "en": {
       "title": "Focus Order",
@@ -585,6 +630,7 @@
     "localPriority": "A"
   },
   "2.4.4": {
+    "id": "2.4.4",
     "sortKey": "20404",
     "en": {
       "title": "Link Purpose (In Context)",
@@ -598,6 +644,7 @@
     "localPriority": "A"
   },
   "2.4.5": {
+    "id": "2.4.5",
     "sortKey": "20405",
     "en": {
       "title": "Multiple Ways",
@@ -611,6 +658,7 @@
     "localPriority": "AA"
   },
   "2.4.6": {
+    "id": "2.4.6",
     "sortKey": "20406",
     "en": {
       "title": "Headings and Labels",
@@ -624,6 +672,7 @@
     "localPriority": "A"
   },
   "2.4.7": {
+    "id": "2.4.7",
     "sortKey": "20407",
     "en": {
       "title": "Focus Visible",
@@ -637,6 +686,7 @@
     "localPriority": "A"
   },
   "2.4.8": {
+    "id": "2.4.8",
     "sortKey": "20408",
     "en": {
       "title": "Location",
@@ -650,6 +700,7 @@
     "localPriority": "AA"
   },
   "2.4.9": {
+    "id": "2.4.9",
     "sortKey": "20409",
     "en": {
       "title": "Link Purpose (Link Only)",
@@ -663,6 +714,7 @@
     "localPriority": "AAA"
   },
   "2.4.10": {
+    "id": "2.4.10",
     "sortKey": "20410",
     "en": {
       "title": "Section Headings",
@@ -676,6 +728,7 @@
     "localPriority": "AA"
   },
   "2.5.1": {
+    "id": "2.5.1",
     "sortKey": "20501",
     "en": {
       "title": "Pointer Gestures",
@@ -689,6 +742,7 @@
     "localPriority": "A"
   },
   "2.5.2": {
+    "id": "2.5.2",
     "sortKey": "20502",
     "en": {
       "title": "Pointer Cancellation",
@@ -702,6 +756,7 @@
     "localPriority": "A"
   },
   "2.5.3": {
+    "id": "2.5.3",
     "sortKey": "20503",
     "en": {
       "title": "Label in Name",
@@ -715,6 +770,7 @@
     "localPriority": "A"
   },
   "2.5.4": {
+    "id": "2.5.4",
     "sortKey": "20504",
     "en": {
       "title": "Motion Actuation",
@@ -728,6 +784,7 @@
     "localPriority": "A"
   },
   "2.5.5": {
+    "id": "2.5.5",
     "sortKey": "20505",
     "en": {
       "title": "Target Size",
@@ -741,6 +798,7 @@
     "localPriority": "AA"
   },
   "2.5.6": {
+    "id": "2.5.6",
     "sortKey": "20506",
     "en": {
       "title": "Concurrent Input Mechanisms",
@@ -754,6 +812,7 @@
     "localPriority": "AAA"
   },
   "3.1.1": {
+    "id": "3.1.1",
     "sortKey": "30101",
     "en": {
       "title": "Language of Page",
@@ -767,6 +826,7 @@
     "localPriority": "A"
   },
   "3.1.2": {
+    "id": "3.1.2",
     "sortKey": "30102",
     "en": {
       "title": "Language of Parts",
@@ -780,6 +840,7 @@
     "localPriority": "AA"
   },
   "3.1.3": {
+    "id": "3.1.3",
     "sortKey": "30103",
     "en": {
       "title": "Unusual Words",
@@ -793,6 +854,7 @@
     "localPriority": "AAA"
   },
   "3.1.4": {
+    "id": "3.1.4",
     "sortKey": "30104",
     "en": {
       "title": "Abbreviations",
@@ -806,6 +868,7 @@
     "localPriority": "AAA"
   },
   "3.1.5": {
+    "id": "3.1.5",
     "sortKey": "30105",
     "en": {
       "title": "Reading Level",
@@ -819,6 +882,7 @@
     "localPriority": "AAA"
   },
   "3.1.6": {
+    "id": "3.1.6",
     "sortKey": "30106",
     "en": {
       "title": "Pronunciation",
@@ -832,6 +896,7 @@
     "localPriority": "AAA"
   },
   "3.2.1": {
+    "id": "3.2.1",
     "sortKey": "30201",
     "en": {
       "title": "On Focus",
@@ -845,6 +910,7 @@
     "localPriority": "A"
   },
   "3.2.2": {
+    "id": "3.2.2",
     "sortKey": "30202",
     "en": {
       "title": "On Input",
@@ -858,6 +924,7 @@
     "localPriority": "A"
   },
   "3.2.3": {
+    "id": "3.2.3",
     "sortKey": "30203",
     "en": {
       "title": "Consistent Navigation",
@@ -871,6 +938,7 @@
     "localPriority": "A"
   },
   "3.2.4": {
+    "id": "3.2.4",
     "sortKey": "30204",
     "en": {
       "title": "Consistent Identification",
@@ -884,6 +952,7 @@
     "localPriority": "A"
   },
   "3.2.5": {
+    "id": "3.2.5",
     "sortKey": "30205",
     "en": {
       "title": "Change on Request",
@@ -897,6 +966,7 @@
     "localPriority": "AAA"
   },
   "3.3.1": {
+    "id": "3.3.1",
     "sortKey": "30301",
     "en": {
       "title": "Error Identification",
@@ -910,6 +980,7 @@
     "localPriority": "A"
   },
   "3.3.2": {
+    "id": "3.3.2",
     "sortKey": "30302",
     "en": {
       "title": "Labels or Instructions",
@@ -923,6 +994,7 @@
     "localPriority": "A"
   },
   "3.3.3": {
+    "id": "3.3.3",
     "sortKey": "30303",
     "en": {
       "title": "Error Suggestion",
@@ -936,6 +1008,7 @@
     "localPriority": "AA"
   },
   "3.3.4": {
+    "id": "3.3.4",
     "sortKey": "30304",
     "en": {
       "title": "Error Prevention (Legal, Financial, Data)",
@@ -949,6 +1022,7 @@
     "localPriority": "AA"
   },
   "3.3.5": {
+    "id": "3.3.5",
     "sortKey": "30305",
     "en": {
       "title": "Help",
@@ -962,6 +1036,7 @@
     "localPriority": "AAA"
   },
   "3.3.6": {
+    "id": "3.3.6",
     "sortKey": "30306",
     "en": {
       "title": "Error Prevention (All)",
@@ -975,6 +1050,7 @@
     "localPriority": "AAA"
   },
   "4.1.1": {
+    "id": "4.1.1",
     "sortKey": "40101",
     "en": {
       "title": "Parsing",
@@ -988,6 +1064,7 @@
     "localPriority": "A"
   },
   "4.1.2": {
+    "id": "4.1.2",
     "sortKey": "40102",
     "en": {
       "title": "Name, Role, Value",
@@ -1001,6 +1078,7 @@
     "localPriority": "A"
   },
   "4.1.3": {
+    "id": "4.1.3",
     "sortKey": "40103",
     "en": {
       "title": "Status Messages",

--- a/data/json/wcag-sc.json
+++ b/data/json/wcag-sc.json
@@ -1,5 +1,6 @@
 {
   "1.1.1": {
+    "sortKey": "10101",
     "en": {
       "title": "Non-text Content",
       "url": "https://www.w3.org/TR/WCAG21/#non-text-content"
@@ -12,6 +13,7 @@
     "localPriority": "A"
   },
   "1.2.1": {
+    "sortKey": "10201",
     "en": {
       "title": "Audio-only and Video-only (Prerecorded)",
       "url": "https://www.w3.org/TR/WCAG21/#audio-only-and-video-only-prerecorded"
@@ -24,6 +26,7 @@
     "localPriority": "A"
   },
   "1.2.2": {
+    "sortKey": "10202",
     "en": {
       "title": "Captions (Prerecorded)",
       "url": "https://www.w3.org/TR/WCAG21/#captions-prerecorded"
@@ -36,6 +39,7 @@
     "localPriority": "A"
   },
   "1.2.3": {
+    "sortKey": "10203",
     "en": {
       "title": "Audio Description or Media Alternative (Prerecorded)",
       "url": "https://www.w3.org/TR/WCAG21/#audio-description-or-media-alternative-prerecorded"
@@ -48,6 +52,7 @@
     "localPriority": "A"
   },
   "1.2.4": {
+    "sortKey": "10204",
     "en": {
       "title": "Captions (Live)",
       "url": "https://www.w3.org/TR/WCAG21/#captions-live"
@@ -60,6 +65,7 @@
     "localPriority": "AA"
   },
   "1.2.5": {
+    "sortKey": "10205",
     "en": {
       "title": "Audio Description (Prerecorded)",
       "url": "https://www.w3.org/TR/WCAG21/#audio-description-prerecorded"
@@ -72,6 +78,7 @@
     "localPriority": "AA"
   },
   "1.2.6": {
+    "sortKey": "10206",
     "en": {
       "title": "Sign Language (Prerecorded)",
       "url": "https://www.w3.org/TR/WCAG21/#sign-language-prerecorded"
@@ -84,6 +91,7 @@
     "localPriority": "AA"
   },
   "1.2.7": {
+    "sortKey": "10207",
     "en": {
       "title": "Extended Audio Description (Prerecorded)",
       "url": "https://www.w3.org/TR/WCAG21/#extended-audio-description-prerecorded"
@@ -96,6 +104,7 @@
     "localPriority": "AAA"
   },
   "1.2.8": {
+    "sortKey": "10208",
     "en": {
       "title": "Media Alternative (Prerecorded)",
       "url": "https://www.w3.org/TR/WCAG21/#media-alternative-prerecorded"
@@ -108,6 +117,7 @@
     "localPriority": "AAA"
   },
   "1.2.9": {
+    "sortKey": "10209",
     "en": {
       "title": "Audio-only (Live)",
       "url": "https://www.w3.org/TR/WCAG21/#audio-only-live"
@@ -120,6 +130,7 @@
     "localPriority": "AAA"
   },
   "1.3.1": {
+    "sortKey": "10301",
     "en": {
       "title": "Info and Relationships",
       "url": "https://www.w3.org/TR/WCAG21/#info-and-relationships"
@@ -132,6 +143,7 @@
     "localPriority": "A"
   },
   "1.3.2": {
+    "sortKey": "10302",
     "en": {
       "title": "Meaningful Sequence",
       "url": "https://www.w3.org/TR/WCAG21/#meaningful-sequence"
@@ -144,6 +156,7 @@
     "localPriority": "A"
   },
   "1.3.3": {
+    "sortKey": "10303",
     "en": {
       "title": "Sensory Characteristics",
       "url": "https://www.w3.org/TR/WCAG21/#sensory-characteristics"
@@ -156,6 +169,7 @@
     "localPriority": "A"
   },
   "1.3.4": {
+    "sortKey": "10304",
     "en": {
       "title": "Orientation",
       "url": "https://www.w3.org/TR/WCAG21/#orientation"
@@ -168,6 +182,7 @@
     "localPriority": "A"
   },
   "1.3.5": {
+    "sortKey": "10305",
     "en": {
       "title": "Identify Input Purpose",
       "url": "https://www.w3.org/TR/WCAG21/#identify-input-purpose"
@@ -180,6 +195,7 @@
     "localPriority": "AAA"
   },
   "1.3.6": {
+    "sortKey": "10306",
     "en": {
       "title": "Identify Purpose",
       "url": "https://www.w3.org/TR/WCAG21/#identify-purpose"
@@ -192,6 +208,7 @@
     "localPriority": "AAA"
   },
   "1.4.1": {
+    "sortKey": "10401",
     "en": {
       "title": "Use of Color",
       "url": "https://www.w3.org/TR/WCAG21/#use-of-color"
@@ -204,6 +221,7 @@
     "localPriority": "A"
   },
   "1.4.2": {
+    "sortKey": "10402",
     "en": {
       "title": "Audio Control",
       "url": "https://www.w3.org/TR/WCAG21/#audio-control"
@@ -216,6 +234,7 @@
     "localPriority": "A"
   },
   "1.4.3": {
+    "sortKey": "10403",
     "en": {
       "title": "Contrast (Minimum)",
       "url": "https://www.w3.org/TR/WCAG21/#contrast-minimum"
@@ -228,6 +247,7 @@
     "localPriority": "A"
   },
   "1.4.4": {
+    "sortKey": "10404",
     "en": {
       "title": "Resize text",
       "url": "https://www.w3.org/TR/WCAG21/#resize-text"
@@ -240,6 +260,7 @@
     "localPriority": "A"
   },
   "1.4.5": {
+    "sortKey": "10405",
     "en": {
       "title": "Images of Text",
       "url": "https://www.w3.org/TR/WCAG21/#images-of-text"
@@ -252,6 +273,7 @@
     "localPriority": "AA"
   },
   "1.4.6": {
+    "sortKey": "10406",
     "en": {
       "title": "Contrast (Enhanced)",
       "url": "https://www.w3.org/TR/WCAG21/#contrast-enhanced"
@@ -264,6 +286,7 @@
     "localPriority": "AA"
   },
   "1.4.7": {
+    "sortKey": "10407",
     "en": {
       "title": "Low or No Background Audio",
       "url": "https://www.w3.org/TR/WCAG21/#low-or-no-background-audio"
@@ -276,6 +299,7 @@
     "localPriority": "AA"
   },
   "1.4.8": {
+    "sortKey": "10408",
     "en": {
       "title": "Visual Presentation",
       "url": "https://www.w3.org/TR/WCAG21/#visual-presentation"
@@ -288,6 +312,7 @@
     "localPriority": "AAA"
   },
   "1.4.9": {
+    "sortKey": "10409",
     "en": {
       "title": "Images of Text (No Exception)",
       "url": "https://www.w3.org/TR/WCAG21/#images-of-text-no-exception"
@@ -300,6 +325,7 @@
     "localPriority": "AA"
   },
   "1.4.10": {
+    "sortKey": "10410",
     "en": {
       "title": "Reflow",
       "url": "https://www.w3.org/TR/WCAG21/#reflow"
@@ -312,6 +338,7 @@
     "localPriority": "AA"
   },
   "1.4.11": {
+    "sortKey": "10411",
     "en": {
       "title": "Non-text Contrast",
       "url": "https://www.w3.org/TR/WCAG21/#non-text-contrast"
@@ -324,6 +351,7 @@
     "localPriority": "A"
   },
   "1.4.12": {
+    "sortKey": "10412",
     "en": {
       "title": "Text Spacing",
       "url": "https://www.w3.org/TR/WCAG21/#text-spacing"
@@ -336,6 +364,7 @@
     "localPriority": "A"
   },
   "1.4.13": {
+    "sortKey": "10413",
     "en": {
       "title": "Content on Hover or Focus",
       "url": "https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus"
@@ -348,6 +377,7 @@
     "localPriority": "一部A"
   },
   "2.1.1": {
+    "sortKey": "20101",
     "en": {
       "title": "Keyboard",
       "url": "https://www.w3.org/TR/WCAG21/#keyboard"
@@ -360,6 +390,7 @@
     "localPriority": "A"
   },
   "2.1.2": {
+    "sortKey": "20102",
     "en": {
       "title": "No Keyboard Trap",
       "url": "https://www.w3.org/TR/WCAG21/#no-keyboard-trap"
@@ -372,6 +403,7 @@
     "localPriority": "A"
   },
   "2.1.3": {
+    "sortKey": "20103",
     "en": {
       "title": "Keyboard (No Exception)",
       "url": "https://www.w3.org/TR/WCAG21/#keyboard-no-exception"
@@ -384,6 +416,7 @@
     "localPriority": "A"
   },
   "2.1.4": {
+    "sortKey": "20104",
     "en": {
       "title": "Character Key Shortcuts",
       "url": "https://www.w3.org/TR/WCAG21/#character-key-shortcuts"
@@ -396,6 +429,7 @@
     "localPriority": "A"
   },
   "2.2.1": {
+    "sortKey": "20201",
     "en": {
       "title": "Timing Adjustable",
       "url": "https://www.w3.org/TR/WCAG21/#timing-adjustable"
@@ -408,6 +442,7 @@
     "localPriority": "A"
   },
   "2.2.2": {
+    "sortKey": "20202",
     "en": {
       "title": "Pause, Stop, Hide",
       "url": "https://www.w3.org/TR/WCAG21/#pause-stop-hide"
@@ -420,6 +455,7 @@
     "localPriority": "A"
   },
   "2.2.3": {
+    "sortKey": "20203",
     "en": {
       "title": "No Timing",
       "url": "https://www.w3.org/TR/WCAG21/#no-timing"
@@ -432,6 +468,7 @@
     "localPriority": "AA"
   },
   "2.2.4": {
+    "sortKey": "20204",
     "en": {
       "title": "Interruptions",
       "url": "https://www.w3.org/TR/WCAG21/#interruptions"
@@ -444,6 +481,7 @@
     "localPriority": "AA"
   },
   "2.2.5": {
+    "sortKey": "20205",
     "en": {
       "title": "Re-authenticating",
       "url": "https://www.w3.org/TR/WCAG21/#re-authenticating"
@@ -456,6 +494,7 @@
     "localPriority": "AA"
   },
   "2.2.6": {
+    "sortKey": "20206",
     "en": {
       "title": "Timeouts",
       "url": "https://www.w3.org/TR/WCAG21/#timeouts"
@@ -468,6 +507,7 @@
     "localPriority": "AAA"
   },
   "2.3.1": {
+    "sortKey": "20301",
     "en": {
       "title": "Three Flashes or Below Threshold",
       "url": "https://www.w3.org/TR/WCAG21/#three-flashes-or-below-threshold"
@@ -480,6 +520,7 @@
     "localPriority": "A"
   },
   "2.3.2": {
+    "sortKey": "20302",
     "en": {
       "title": "Three Flashes",
       "url": "https://www.w3.org/TR/WCAG21/#three-flashes"
@@ -492,6 +533,7 @@
     "localPriority": "A"
   },
   "2.3.3": {
+    "sortKey": "20303",
     "en": {
       "title": "Animation from Interactions",
       "url": "https://www.w3.org/TR/WCAG21/#animation-from-interactions"
@@ -504,6 +546,7 @@
     "localPriority": "AAA"
   },
   "2.4.1": {
+    "sortKey": "20401",
     "en": {
       "title": "Bypass Blocks",
       "url": "https://www.w3.org/TR/WCAG21/#bypass-blocks"
@@ -516,6 +559,7 @@
     "localPriority": "A"
   },
   "2.4.2": {
+    "sortKey": "20402",
     "en": {
       "title": "Page Titled",
       "url": "https://www.w3.org/TR/WCAG21/#page-titled"
@@ -528,6 +572,7 @@
     "localPriority": "A"
   },
   "2.4.3": {
+    "sortKey": "20403",
     "en": {
       "title": "Focus Order",
       "url": "https://www.w3.org/TR/WCAG21/#focus-order"
@@ -540,6 +585,7 @@
     "localPriority": "A"
   },
   "2.4.4": {
+    "sortKey": "20404",
     "en": {
       "title": "Link Purpose (In Context)",
       "url": "https://www.w3.org/TR/WCAG21/#link-purpose-in-context"
@@ -552,6 +598,7 @@
     "localPriority": "A"
   },
   "2.4.5": {
+    "sortKey": "20405",
     "en": {
       "title": "Multiple Ways",
       "url": "https://www.w3.org/TR/WCAG21/#multiple-ways"
@@ -564,6 +611,7 @@
     "localPriority": "AA"
   },
   "2.4.6": {
+    "sortKey": "20406",
     "en": {
       "title": "Headings and Labels",
       "url": "https://www.w3.org/TR/WCAG21/#headings-and-labels"
@@ -576,6 +624,7 @@
     "localPriority": "A"
   },
   "2.4.7": {
+    "sortKey": "20407",
     "en": {
       "title": "Focus Visible",
       "url": "https://www.w3.org/TR/WCAG21/#focus-visible"
@@ -588,6 +637,7 @@
     "localPriority": "A"
   },
   "2.4.8": {
+    "sortKey": "20408",
     "en": {
       "title": "Location",
       "url": "https://www.w3.org/TR/WCAG21/#location"
@@ -600,6 +650,7 @@
     "localPriority": "AA"
   },
   "2.4.9": {
+    "sortKey": "20409",
     "en": {
       "title": "Link Purpose (Link Only)",
       "url": "https://www.w3.org/TR/WCAG21/#link-purpose-link-only"
@@ -612,6 +663,7 @@
     "localPriority": "AAA"
   },
   "2.4.10": {
+    "sortKey": "20410",
     "en": {
       "title": "Section Headings",
       "url": "https://www.w3.org/TR/WCAG21/#section-headings"
@@ -624,6 +676,7 @@
     "localPriority": "AA"
   },
   "2.5.1": {
+    "sortKey": "20501",
     "en": {
       "title": "Pointer Gestures",
       "url": "https://www.w3.org/TR/WCAG21/#pointer-gestures"
@@ -636,6 +689,7 @@
     "localPriority": "A"
   },
   "2.5.2": {
+    "sortKey": "20502",
     "en": {
       "title": "Pointer Cancellation",
       "url": "https://www.w3.org/TR/WCAG21/#pointer-cancellation"
@@ -648,6 +702,7 @@
     "localPriority": "A"
   },
   "2.5.3": {
+    "sortKey": "20503",
     "en": {
       "title": "Label in Name",
       "url": "https://www.w3.org/TR/WCAG21/#label-in-name"
@@ -660,6 +715,7 @@
     "localPriority": "A"
   },
   "2.5.4": {
+    "sortKey": "20504",
     "en": {
       "title": "Motion Actuation",
       "url": "https://www.w3.org/TR/WCAG21/#motion-actuation"
@@ -672,6 +728,7 @@
     "localPriority": "A"
   },
   "2.5.5": {
+    "sortKey": "20505",
     "en": {
       "title": "Target Size",
       "url": "https://www.w3.org/TR/WCAG21/#target-size"
@@ -684,6 +741,7 @@
     "localPriority": "AA"
   },
   "2.5.6": {
+    "sortKey": "20506",
     "en": {
       "title": "Concurrent Input Mechanisms",
       "url": "https://www.w3.org/TR/WCAG21/#concurrent-input-mechanisms"
@@ -696,6 +754,7 @@
     "localPriority": "AAA"
   },
   "3.1.1": {
+    "sortKey": "30101",
     "en": {
       "title": "Language of Page",
       "url": "https://www.w3.org/TR/WCAG21/#language-of-page"
@@ -708,6 +767,7 @@
     "localPriority": "A"
   },
   "3.1.2": {
+    "sortKey": "30102",
     "en": {
       "title": "Language of Parts",
       "url": "https://www.w3.org/TR/WCAG21/#language-of-parts"
@@ -720,6 +780,7 @@
     "localPriority": "AA"
   },
   "3.1.3": {
+    "sortKey": "30103",
     "en": {
       "title": "Unusual Words",
       "url": "https://www.w3.org/TR/WCAG21/#unusual-words"
@@ -732,6 +793,7 @@
     "localPriority": "AAA"
   },
   "3.1.4": {
+    "sortKey": "30104",
     "en": {
       "title": "Abbreviations",
       "url": "https://www.w3.org/TR/WCAG21/#abbreviations"
@@ -744,6 +806,7 @@
     "localPriority": "AAA"
   },
   "3.1.5": {
+    "sortKey": "30105",
     "en": {
       "title": "Reading Level",
       "url": "https://www.w3.org/TR/WCAG21/#reading-level"
@@ -756,6 +819,7 @@
     "localPriority": "AAA"
   },
   "3.1.6": {
+    "sortKey": "30106",
     "en": {
       "title": "Pronunciation",
       "url": "https://www.w3.org/TR/WCAG21/#pronunciation"
@@ -768,6 +832,7 @@
     "localPriority": "AAA"
   },
   "3.2.1": {
+    "sortKey": "30201",
     "en": {
       "title": "On Focus",
       "url": "https://www.w3.org/TR/WCAG21/#on-focus"
@@ -780,6 +845,7 @@
     "localPriority": "A"
   },
   "3.2.2": {
+    "sortKey": "30202",
     "en": {
       "title": "On Input",
       "url": "https://www.w3.org/TR/WCAG21/#on-input"
@@ -792,6 +858,7 @@
     "localPriority": "A"
   },
   "3.2.3": {
+    "sortKey": "30203",
     "en": {
       "title": "Consistent Navigation",
       "url": "https://www.w3.org/TR/WCAG21/#consistent-navigation"
@@ -804,6 +871,7 @@
     "localPriority": "A"
   },
   "3.2.4": {
+    "sortKey": "30204",
     "en": {
       "title": "Consistent Identification",
       "url": "https://www.w3.org/TR/WCAG21/#consistent-identification"
@@ -816,6 +884,7 @@
     "localPriority": "A"
   },
   "3.2.5": {
+    "sortKey": "30205",
     "en": {
       "title": "Change on Request",
       "url": "https://www.w3.org/TR/WCAG21/#change-on-request"
@@ -828,6 +897,7 @@
     "localPriority": "AAA"
   },
   "3.3.1": {
+    "sortKey": "30301",
     "en": {
       "title": "Error Identification",
       "url": "https://www.w3.org/TR/WCAG21/#error-identification"
@@ -840,6 +910,7 @@
     "localPriority": "A"
   },
   "3.3.2": {
+    "sortKey": "30302",
     "en": {
       "title": "Labels or Instructions",
       "url": "https://www.w3.org/TR/WCAG21/#labels-or-instructions"
@@ -852,6 +923,7 @@
     "localPriority": "A"
   },
   "3.3.3": {
+    "sortKey": "30303",
     "en": {
       "title": "Error Suggestion",
       "url": "https://www.w3.org/TR/WCAG21/#error-suggestion"
@@ -864,6 +936,7 @@
     "localPriority": "AA"
   },
   "3.3.4": {
+    "sortKey": "30304",
     "en": {
       "title": "Error Prevention (Legal, Financial, Data)",
       "url": "https://www.w3.org/TR/WCAG21/#error-prevention-legal-financial-data"
@@ -876,6 +949,7 @@
     "localPriority": "AA"
   },
   "3.3.5": {
+    "sortKey": "30305",
     "en": {
       "title": "Help",
       "url": "https://www.w3.org/TR/WCAG21/#help"
@@ -888,6 +962,7 @@
     "localPriority": "AAA"
   },
   "3.3.6": {
+    "sortKey": "30306",
     "en": {
       "title": "Error Prevention (All)",
       "url": "https://www.w3.org/TR/WCAG21/#error-prevention-all"
@@ -900,6 +975,7 @@
     "localPriority": "AAA"
   },
   "4.1.1": {
+    "sortKey": "40101",
     "en": {
       "title": "Parsing",
       "url": "https://www.w3.org/TR/WCAG21/#parsing"
@@ -912,6 +988,7 @@
     "localPriority": "A"
   },
   "4.1.2": {
+    "sortKey": "40102",
     "en": {
       "title": "Name, Role, Value",
       "url": "https://www.w3.org/TR/WCAG21/#name-role-value"
@@ -924,6 +1001,7 @@
     "localPriority": "A"
   },
   "4.1.3": {
+    "sortKey": "40103",
     "en": {
       "title": "Status Messages",
       "url": "https://www.w3.org/TR/WCAG21/#status-messages"

--- a/tools/yaml2rst/a11y_guidelines.py
+++ b/tools/yaml2rst/a11y_guidelines.py
@@ -1,0 +1,654 @@
+import datetime
+import re
+from urllib.parse import quote as url_encode
+from config import CHECK_TARGETS, PLATFORM_NAMES, SEVERITY_TAGS, IMPLEMENTATION_TARGETS
+
+class Guideline:
+    all_guidelines = {}
+
+    def __init__(self, gl):
+        self.id = gl['id']
+        self.sortKey = gl['sortKey']
+        self.title = gl['title']
+        self.platform = gl['platform']
+        self.guideline = gl['guideline']
+        self.intent = gl['intent']
+        self.src_path = gl['src_path']
+        self.category = None
+        Category.get_by_id(gl['category']).add_guideline(self)
+        self.checks = []
+        self.faqs = []
+        for check_id in gl['checks']:
+            self.add_check(Check.get_by_id(check_id))
+        self.sc = []
+        for sc in gl['sc']:
+            self.add_sc(WCAG_SC.get_by_id(sc))
+
+        self.info = []
+        if 'info' in gl:
+            for info in gl['info']:
+                self.add_info(InfoRef(info))
+
+        Guideline.all_guidelines[self.id] = self
+
+    def set_category(self, category):
+        self.category = category
+        category.add_guideline(self)
+
+    def add_check(self, check):
+        if check in self.checks:
+            return
+        self.checks.append(check)
+        check.add_guideline(self)
+
+    def add_faq(self, faq):
+        if faq in self.faqs:
+            return
+        self.faqs.append(faq)
+        faq.add_guideline(self)
+
+    def add_sc(self, sc):
+        if sc in self.sc:
+            return
+        self.sc.append(sc)
+        sc.add_guideline(self)
+
+    def add_info(self, info):
+        if info in self.info:
+            return
+        self.info.append(info)
+        for check in self.checks:
+            check.add_info(info)
+        if not info.internal:
+            return
+        info.add_guideline(self)
+
+    def get_category_and_id(self, lang):
+        return {
+            'category': self.category.get_name(lang),
+            'guideline': self.id
+        }
+
+    def template_object(self, lang):
+        template_object = {
+            'id': self.id,
+            'title': self.title[lang],
+            'platform': join_items(self.platform, lang),
+            'guideline': self.guideline[lang],
+            'intent': self.intent[lang],
+            'category': self.category.names[lang],
+            'checks': [check.template_object(lang, platform=self.platform) for check in self.checks],
+            'scs': [sc.template_object(lang) for sc in self.sc]
+        }
+        if len(self.faqs):
+            template_object['faqs'] = [faq.id for faq in sorted(self.faqs, key=lambda item: item.sortKey)]
+        if len(self.info):
+            template_object['info'] = [inforef.refstring() for inforef in self.info]
+        return template_object
+
+    @classmethod
+    def get_by_id(cls, id):
+        return cls.all_guidelines.get(id)
+
+class Check:
+    all_checks = {}
+
+    def __init__(self, check):
+        self.id = check['id']
+        self.check = check['check']
+        self.severity = check['severity']
+        self.target = check['target']
+        self.platform = check['platform']
+        self.src_path = check['src_path']
+        self.procedures = []
+        self.implementations = []
+        if 'procedures' in check:
+            for proc in check['procedures']:
+                self.procedures.append(Procedure(proc, self))
+        if 'implementations' in check:
+            self.implementations = [Implementation(**implementation) for implementation in check['implementations']]
+        self.guidelines = []
+        self.faqs = []
+        self.info = []
+        Check.all_checks[self.id] = self
+
+    def add_guideline(self, guideline):
+        if guideline in self.guidelines:
+            return
+        self.guidelines.append(guideline)
+
+    def add_faq(self, faq):
+        if faq in self.faqs:
+            return
+        self.faqs.append(faq)
+        faq.add_check(self)
+
+    def add_info(self, info):
+        if info in self.info:
+            return
+        self.info.append(info)
+        if not info.internal:
+            return
+        info.add_check(self)
+
+    def procedure_platforms(self):
+        return sorted(list(set([procedure.platform for procedure in self.procedures])))
+
+    def template_object(self, lang, **kwargs):
+        if 'platform' in kwargs:
+            gl_platform = kwargs['platform']
+        else:
+            gl_platform = []
+        template_object = {
+            'id': self.id,
+            'check': self.check[lang],
+            'severity': SEVERITY_TAGS[self.severity][lang],
+            'target': CHECK_TARGETS[self.target][lang],
+            'platform': join_items(self.platform, lang),
+            'guidelines': []
+        }
+        if len(self.procedures) > 0:
+            if len(gl_platform) == 0:
+                template_object['procedures'] = [procedure.template_object(lang) for procedure in self.procedures]
+            else:
+                template_object['procedures'] = []
+                for proc in self.procedures:
+                    proc_platform = proc.platform
+                    if proc_platform == 'general' or proc_platform in gl_platform:
+                        template_object['procedures'].append(proc.template_object(lang))
+        if len(self.implementations) > 0:
+            template_object['implementations'] = [implementation.template_object(lang) for implementation in self.implementations]
+        if len(self.info) > 0:
+            template_object['info_refs'] = [inforef.refstring() for inforef in self.info]
+        if len(self.faqs) > 0:
+            template_object['faqs'] = [faq.id for faq in sorted(self.faqs, key=lambda item: item.sortKey)]
+        sorted_guidelines = sorted(self.guidelines, key=lambda item: item.sortKey)
+        for gl in sorted_guidelines:
+            template_object['guidelines'].append(gl.get_category_and_id(lang))
+        return template_object
+
+    @classmethod
+    def get_by_id(cls, id):
+        return cls.all_checks.get(id)
+
+    @classmethod
+    def template_object_all(cls, lang):
+        sorted_checks = sorted(cls.all_checks, key=lambda x: cls.all_checks[x].id)
+        return [cls.all_checks[check_id].template_object(lang) for check_id in sorted_checks]
+
+class FAQ:
+    all_faqs = {}
+
+    def __init__(self, faq):
+        self.id = faq['id']
+        self.sortKey = faq['sortKey']
+        self.updated = datetime.datetime.fromisoformat(faq['updated'])
+        self.title = faq['title']
+        self.problem = faq['problem']
+        self.solution = faq['solution']
+        self.explanation = faq['explanation']
+        self.src_path = faq['src_path']
+        self.guidelines = []
+        if 'guidelines' in faq:
+            for guideline_id in faq['guidelines']:
+                self.add_guideline(Guideline.get_by_id(guideline_id))
+
+        self.tags = []
+        for tag in faq['tags']:
+            self.add_tag(FAQ_Tag.get_by_id(tag))
+
+        self.checks = []    
+        if 'checks' in faq:
+            for check_id in faq['checks']:
+                self.add_check(Check.get_by_id(check_id))
+
+        self.info = []
+        if 'info' in faq:
+            for info in faq['info']:
+                self.add_info(InfoRef(info))
+
+        FAQ.all_faqs[self.id] = self
+
+    def add_guideline(self, guideline):
+        if guideline in self.guidelines:
+            return
+        self.guidelines.append(guideline)
+        guideline.add_faq(self)
+
+    def add_check(self, check):
+        if check in self.checks:
+            return
+        self.checks.append(check)
+        check.add_faq(self)
+
+    def add_tag(self, tag):
+        if tag in self.tags:
+            return
+        self.tags.append(tag)
+        tag.add_faq(self)
+
+
+
+    def add_info(self, info):
+        if info in self.info:
+            return
+        self.info.append(info)
+        if not info.internal:
+            return
+        info.add_faq(self)
+
+    def get_dependency(self):
+        dependency = [self.src_path]
+        if len(self.guidelines):
+            dependency.extend([guideline.src_path for guideline in self.guidelines])
+        if len(self.checks):
+            dependency.extend([check.src_path for check in self.checks])
+        return uniq(dependency)
+
+    def template_object(self, lang):
+        template_object = {
+            'id': self.id,
+            'updated': self.updated,
+            'updated_year': self.updated.year,
+            'updated_month': self.updated.month,
+            'updated_day': self.updated.day,
+            'title': self.title[lang],
+            'problem': self.problem[lang],
+            'solution': self.solution[lang],
+            'explanation': self.explanation[lang],
+            'tags': [tag.id for tag in sorted(self.tags, key=lambda item: item.id)],
+        }
+        if len(self.guidelines):
+            sorted_guidelines = sorted(self.guidelines, key=lambda item: item.sortKey)
+            template_object['guidelines'] = [guideline.get_category_and_id(lang) for guideline in sorted_guidelines]
+        if len(self.checks):
+            sorted_checks = sorted(self.checks, key=lambda item: item.id)
+            template_object['checks'] = [{'id': check.id, 'check': check.check[lang]} for check in sorted_checks]
+        if len(self.info):
+            template_object['info'] = [inforef.refstring() for inforef in self.info]
+        return template_object
+
+    @classmethod
+    def list_all(cls, **kwargs):
+        if 'sort_by' in kwargs:
+            if kwargs['sort_by'] == 'date':
+                return sorted(cls.all_faqs.values(), key=lambda faq: faq.updated, reverse=True)
+            elif kwargs['sort_by'] == 'sortKey':
+                return sorted(cls.all_faqs.values(), key=lambda faq: faq.sortKey)
+        return sorted(cls.all_faqs.values(), key=lambda faq: faq.sortKey)
+
+class Category:
+    all_categories = {}
+
+    def __init__(self, id, names):
+        self.id = id
+        self.names = names
+        self.guidelines = []
+        Category.all_categories[id] = self
+
+    def add_guideline(self, guideline):
+        if guideline in self.guidelines:
+            return
+        self.guidelines.append(guideline)
+        guideline.set_category(self)
+
+    def get_name(self, lang):
+        if lang in self.names:
+            return self.names[lang]
+        else:
+            return self.names['ja']
+
+    def get_guidelines(self):
+        return sorted(self.guidelines, key=lambda item: item.sortKey)
+
+    def get_dependency(self):
+        dependency = []
+        for guideline in self.guidelines:
+            dependency.append(guideline.src_path)
+            dependency.extend([check.src_path for check in guideline.checks])
+            dependency.extend([faq.src_path for faq in guideline.faqs])
+        return uniq(dependency)
+
+    @classmethod
+    def get_by_id(cls, id):
+        return cls.all_categories.get(id)
+
+    @classmethod
+    def list_all(cls):
+        return cls.all_categories.values()
+
+class FAQ_Tag:
+    all_tags = {}
+
+    def __init__(self, id, names):
+        self.id = id
+        self.names = names
+        self.faqs = []
+        FAQ_Tag.all_tags[id] = self
+
+    def article_count(self):
+        return len(self.faqs)
+
+    def add_faq(self, faq):
+        if faq in self.faqs:
+            return
+        self.faqs.append(faq)
+        faq.add_tag(self)
+
+    def get_name(self, lang):
+        if lang in self.names:
+            return self.names[lang]
+        else:
+            return self.names['en']
+
+    def get_faqs_ids(self):
+        return sorted([str(faq.id) for faq in self.faqs])
+
+    def get_dependency(self):
+        dependency = [faq.src_path for faq in self.faqs]
+        return uniq(dependency)
+
+    def template_object(self, lang):
+        if len(self.faqs) == 0:
+            return None
+        sorted_faqs = sorted(self.faqs, key=lambda item: item.sortKey)
+        return {
+            'tag': self.id,
+            'label': self.names[lang],
+            'articles': [faq.id for faq in sorted_faqs],
+            'count': len(self.faqs)
+        }
+
+    @classmethod
+    def get_by_id(cls, id):
+        return cls.all_tags.get(id)
+
+    @classmethod
+    def list_all(cls, **kwargs):
+        if 'sort_by' in kwargs:
+            if kwargs['sort_by'] == 'count':
+                return sorted(cls.all_tags.values(), key=lambda tag: tag.article_count(), reverse=True)
+            elif kwargs['sort_by'] == 'label':
+                return sorted(cls.all_tags.values(), key=lambda tag: tag.names['en'])
+        return cls.all_tags.values()
+
+class WCAG_SC:
+    all_scs = {}
+
+    def __init__(self, sc):
+        self.id = sc['id']
+        self.sortKey = sc['sortKey']
+        self.level = sc['level']
+        self.localPriority = sc['localPriority']
+        self.title = {
+            'ja': sc['ja']['title'],
+            'en': sc['en']['title']
+        }
+        self.url = {
+            'ja': sc['ja']['url'],
+            'en': sc['en']['url']
+        }
+        self.guidelines = []
+        WCAG_SC.all_scs[self.id] = self
+       
+
+    def add_guideline(self, guideline):
+        if guideline in self.guidelines:
+            return
+        self.guidelines.append(guideline)
+        guideline.add_sc(self)
+
+    def template_object(self, lang):
+        template_object =  {
+            'sc': self.id,
+            'sc_level': self.level,
+            'LocalLevel': self.localPriority,
+            'sc_en_title': self.title['en'],
+            'sc_ja_title': self.title['ja'],
+            'sc_en_url': self.url['en'],
+            'sc_ja_url': self.url['ja']
+        }
+        if len(self.guidelines):
+            sorted_guidelines = sorted(self.guidelines, key=lambda item: item.sortKey)
+            template_object['guidelines'] = [guideline.get_category_and_id(lang) for guideline in sorted_guidelines]
+        return template_object
+
+    @classmethod
+    def get_by_id(cls, id):
+        return cls.all_scs.get(id)
+
+    @classmethod
+    def get_all(cls):
+        sorted_keys = sorted(cls.all_scs.keys(), key=lambda sc: cls.all_scs[sc].sortKey)
+        return {key: cls.get_by_id(key) for key in sorted_keys}
+
+class InfoRef:
+    all_inforefs = {}
+
+    def __new__(cls, id, *args, **kwargs):
+        if id in cls.all_inforefs:
+            return cls.all_inforefs[id]
+        else:
+            instance = super(InfoRef, cls).__new__(cls)
+            cls.all_inforefs[id] = instance
+            return instance
+
+    def __init__(self, inforef):
+        if not hasattr(self, 'initialized'):
+            self.ref = inforef
+            self.id = url_encode(self.ref)
+            self.internal = False if re.match(r'(https?://|\|.+\|)', self.ref) else True
+            self.guidelines = []
+            self.checks = []
+            self.faqs = []
+            self.initialized = True
+
+
+    def add_guideline(self, guideline):
+        if guideline in self.guidelines:
+            return
+        self.guidelines.append(guideline)
+        guideline.add_info(self)
+
+    def add_faq(self, faq):
+        if faq in self.faqs:
+            return
+        self.faqs.append(faq)
+        faq.add_info(self)
+
+    def add_check(self, check):
+        if check in self.checks:
+            return
+        self.checks.append(check)
+        check.add_info(self)
+
+    def refstring(self):
+        if self.internal:
+            return f':ref:`{self.ref}`'
+        else:
+            return self.ref
+
+    def get_guidelines(self, lang):
+        sorted_guidelines = sorted(self.guidelines, key=lambda item: item.sortKey)
+        return [guideline.get_category_and_id(lang) for guideline in sorted_guidelines]
+
+    def get_faqs(self):
+        sorted_faqs = sorted(self.faqs, key=lambda item: item.sortKey)
+        return [faq.id for faq in sorted_faqs]
+
+    @classmethod
+    def get_all_internals(cls):
+        return [info for info in cls.all_inforefs.values() if info.internal]
+
+class Procedure:
+    def __init__(self, procedure, check):
+        self.platform = procedure['platform']
+        self.procedure = procedure['procedure']
+        self.techniques = []
+        if 'techniques' in procedure:
+            for tech in procedure['techniques']:
+                tech_tool = tech['tool']
+                if tech_tool in CheckTool.list_all_ids():
+                    basename = tech_tool
+                else:
+                    basename = 'misc'
+                    tech['tool_display_name'] = tech_tool
+                tech['tool'] = CheckTool.get_by_id(basename)
+                tech_obj = Technique(**tech)
+                example = {
+                    'tool': CheckTool.get_by_id(basename),
+                    'check': check,
+                    'technique': tech_obj
+                }
+                CheckTool.get_by_id(basename).add_example(Example(**example))
+                self.techniques.append(tech_obj)
+        else:
+            self.techniques = None
+
+    def get_platform(self):
+        return self.platform
+
+    def template_object(self, lang):
+        template_object = {
+            'platform': PLATFORM_NAMES[self.platform][lang],
+            'procedure': self.procedure[lang]
+        }
+        if self.techniques:
+            template_object['techniques'] = [technique.template_object(lang) for technique in self.techniques]
+        return template_object
+
+class Technique:
+    def __init__(self, tool, technique, **kwargs):
+        self.tool = tool
+        if 'tool_display_name' in kwargs:
+            self.tool_display_name = kwargs['tool_display_name']
+        else:
+            self.tool_display_name = None
+        self.technique = technique
+        if 'note' in kwargs:
+            self.note = kwargs['note']
+        else:
+            self.note = None
+        if 'YouTube' in kwargs:
+            self.YouTube = YouTube(**kwargs['YouTube'])
+        else:
+            self.YouTube = None
+
+    def template_object(self, lang):
+        if not self.tool_display_name:
+            self.tool_display_name = self.tool.get_name(lang)
+        template_object = {
+            'tool_display_name': self.tool_display_name,
+            'technique': self.technique[lang]
+        }
+        if self.note:
+            template_object['note'] = self.note[lang]        
+        if self.YouTube:
+            template_object['YouTube'] = self.YouTube.template_object()
+        return template_object
+
+class YouTube:
+    def __init__(self, id, title):
+        self.id = id
+        self.title = title
+
+    def template_object(self):
+        return {
+            'id': self.id,
+            'title': self.title
+        }
+    
+class Implementation:
+    def __init__(self, title, methods):
+        self.title = title
+        self.methods = [Method(**method) for method in methods]
+
+    def template_object(self, lang):
+        return {
+            'title': self.title,
+            'methods': [method.template_object(lang) for method in self.methods]
+        }
+
+class Example:
+    def __init__(self, tool, check, technique):
+        self.tool = tool
+        self.check_id = check.id
+        self.check_text = check.check
+        self.check_src_path = check.src_path
+        self.technique = technique
+
+    def template_object(self, lang):
+        template_object = self.technique.template_object(lang)
+        template_object['tool'] = self.tool.id
+        template_object['check_id'] = self.check_id
+        template_object['check_text'] = self.check_text[lang]
+        return template_object
+
+class Method:
+    def __init__(self, platform, method):
+        self.platform = platform
+        self.method = method
+
+    def template_object(self, lang):
+        return {
+            'platform': IMPLEMENTATION_TARGETS[self.platform][lang],
+            'method': self.method
+        }
+    
+class CheckTool:
+    all_tools = {}
+
+    def __init__(self, id, names):
+        self.id = id
+        self.names = names
+        self.examples = []
+        CheckTool.all_tools[id] = self
+
+    def add_example(self, example):
+        self.examples.append(example)
+
+    def get_name(self, lang):
+        if lang in self.names:
+            return self.names[lang]
+        else:
+            return self.names['ja']
+
+    def get_dependency(self):
+        dependency = []
+        for example in self.examples:
+            dependency.append(example.check_src_path)
+        return uniq(dependency)
+
+    def example_template_object(self, lang):
+        template_object = {
+            'tool': self.id
+        }
+        example_objects = []
+        for example in self.examples:
+            example_objects.append(example.template_object(lang)) 
+        template_object['examples'] = sorted(example_objects, key=lambda item: item['check_id'])
+        return template_object
+
+    @classmethod
+    def list_all(cls):
+        return cls.all_tools.values()
+
+    @classmethod
+    def list_all_ids(cls):
+        return cls.all_tools.keys()
+
+    @classmethod
+    def get_by_id(cls, id):
+        return cls.all_tools.get(id)
+
+# Utility functions
+def join_items(items, lang):
+    if lang == 'ja':
+        separator = '、'
+    else:
+        separator = ', '
+    return separator.join([PLATFORM_NAMES[item][lang] for item in items])
+
+def uniq(seq):
+    seen = []
+    return [x for x in seq if x not in seen and not seen.append(x)]

--- a/tools/yaml2rst/config.py
+++ b/tools/yaml2rst/config.py
@@ -1,0 +1,5 @@
+# Default file locations and ohter configuration options for yaml2rst
+
+# List of languages that are available for file generation.
+AVAILABLE_LANGUAGES = ['ja']
+

--- a/tools/yaml2rst/config.py
+++ b/tools/yaml2rst/config.py
@@ -1,5 +1,110 @@
-# Default file locations and ohter configuration options for yaml2rst
+import os
 
+# Default file locations and ohter configuration options for yaml2rst
+#
 # List of languages that are available for file generation.
 AVAILABLE_LANGUAGES = ['ja']
+
+# Directories
+CWD = os.getcwd()
+DATA_DIR = os.path.join(CWD, 'data')
+YAML_DIR = os.path.join(DATA_DIR, 'yaml')
+JSON_DIR = os.path.join(DATA_DIR, 'json')
+DEST_DIR_BASE = 'source'
+
+SRCDIR = {
+    'guidelines': os.path.join(YAML_DIR, "gl"),
+    'checks': os.path.join(YAML_DIR, 'checks'),
+    'faq': os.path.join(YAML_DIR, 'faq'),
+    'schema': os.path.join(JSON_DIR, 'schemas')
+}
+
+SCHEMA_FILENAMES = {
+    'guidelines': 'guideline.json',
+    'checks': 'check.json',
+    'faq': 'faq.json',
+    'common': 'common.json'
+}
+COMMON_SCHEMA_PATH = os.path.join(SRCDIR['schema'], SCHEMA_FILENAMES['common'])
+
+# File paths
+FAQ_INDEX_FILENAME = 'index.rst'
+MAKEFILE_FILENAME = 'incfiles.mk'
+ALL_CHECKS_FILENAME = "allchecks.rst"
+WCAG_MAPPING_FILENAME = "wcag21-mapping.rst"
+PRIORITY_DIFF_FILENAME = "priority-diff.rst"
+MISCDEFS_FILENAME = "defs.txt"
+
+MISC_INFO_SRCFILES = {
+    'wcag_sc': os.path.join(JSON_DIR, 'wcag-sc.json'),
+    'gl_categories': os.path.join(JSON_DIR, 'guideline-categories.json'),
+    'faq_tags': os.path.join(JSON_DIR, 'faq-tags.json'),
+    'info': os.path.join(JSON_DIR, 'info.json')
+}
+
+TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
+TEMPLATE_FILENAMES = {
+    'tool_example': 'checks/examples-tool.rst',
+    'allchecks_text': 'checks/allchecks.rst',
+    'category_page': 'gl-category.rst',
+    'info_to_gl': 'info_to_gl.rst',
+    'info_to_faq': 'info_to_faq.rst',
+    'faq_article': 'faq/article.rst',
+    'faq_tagpage': 'faq/tagpage.rst',
+    'faq_index': 'faq/index.rst',
+    'faq_tag_index': 'faq/tag-index.rst',
+    'faq_article_index': 'faq/article-index.rst',
+    'wcag21mapping': 'wcag21-mapping.rst',
+    'priority_diff': 'priority-diff.rst',
+    'makefile': 'incfiles.mk',
+    'miscdefs': 'misc-defs.txt'
+}
+
+def get_dest_dirnames(lang):
+    """
+    Returns a dictionary of destination directory names for the given language.
+
+    Args:
+        lang (str): Language code
+
+    Returns:
+        dict: Dictionary of destination directory names
+    """
+    if len(AVAILABLE_LANGUAGES) == 1:
+        lang = ''
+    inc_dest_dir = os.path.join(CWD, lang, DEST_DIR_BASE, 'inc')
+    faq_dest_dir = os.path.join(CWD, lang, DEST_DIR_BASE, 'faq')
+    return {
+        'base': os.path.join(CWD, lang),
+        'guidelines': os.path.join(inc_dest_dir, 'gl'),
+        'checks': os.path.join(inc_dest_dir, 'checks'),
+        'misc': os.path.join(inc_dest_dir, 'misc'),
+        'info2gl': os.path.join(inc_dest_dir, 'info2gl'),
+        'info2faq': os.path.join(inc_dest_dir, 'info2faq'),
+        'faq_base': faq_dest_dir,
+        'faq_articles': os.path.join(faq_dest_dir, 'articles'),
+        'faq_tags': os.path.join(faq_dest_dir, 'tags')
+    }
+
+def get_static_dest_files(lang):
+    """
+    Returns a dictionary of static destination file paths for the given language.
+
+    Args:
+        lang (str): Language code
+
+    Returns:
+        dict: Dictionary of static destination file paths
+    """
+    dest_dirnames = get_dest_dirnames(lang)
+    return {
+        'all_checks': os.path.join(dest_dirnames['checks'], ALL_CHECKS_FILENAME),
+        'wcag21mapping': os.path.join(dest_dirnames['misc'], WCAG_MAPPING_FILENAME),
+        'priority_diff': os.path.join(dest_dirnames['misc'], PRIORITY_DIFF_FILENAME),
+        'miscdefs': os.path.join(dest_dirnames['misc'], MISCDEFS_FILENAME),
+        'faq_index': os.path.join(dest_dirnames['faq_base'], FAQ_INDEX_FILENAME),
+        'faq_article_index': os.path.join(dest_dirnames['faq_articles'], FAQ_INDEX_FILENAME),
+        'faq_tag_index': os.path.join(dest_dirnames['faq_tags'], FAQ_INDEX_FILENAME),
+        'makefile': os.path.join(dest_dirnames['base'], MAKEFILE_FILENAME)
+    }
 

--- a/tools/yaml2rst/config.py
+++ b/tools/yaml2rst/config.py
@@ -5,6 +5,106 @@ import os
 # List of languages that are available for file generation.
 AVAILABLE_LANGUAGES = ['ja']
 
+# List of check tools and their names
+CHECK_TOOLS = {
+    'nvda': {
+        'ja': 'NVDA',
+        'en': 'NVDA'
+    },
+    'macos-vo': {
+        'ja': 'macOS VoiceOver',
+        'en': 'macOS VoiceOver'
+    },
+    'axe': {
+        'ja': 'axe DevTools',
+        'en': 'axe DevTools'
+    },
+    'ios-vo': {
+        'ja': 'iOS VoiceOver',
+        'en': 'iOS VoiceOver'
+    },
+    'android-tb': {
+        'ja': 'Android TalkBack',
+        'en': 'Android TalkBack'
+    },
+    'keyboard': {
+        'ja': 'キーボード操作',
+        'en': 'Keyboard'
+    },
+    'misc': {
+        'ja': 'その他のツール',
+        'en': 'Miscellaneous Tools'
+    }
+}
+
+# Check targets
+CHECK_TARGETS = {
+    'design': {
+        'ja': 'デザイン',
+        'en': 'Design'
+    },
+    'code': {
+        'ja': 'コード',
+        'en': 'Code'
+    },
+    'product': {
+        'ja': 'プロダクト',
+        'en': 'Product'
+    }
+}
+
+# Names for checks/guidelines/procedures target platforms
+PLATFORM_NAMES = {
+    'web': {
+        'ja': 'Web',
+        'en': 'Web'
+    },
+    'mobile': {
+        'ja': 'モバイル',
+        'en': 'Mobile'
+    },
+    'general': {
+        'ja': 'Web、モバイル',
+        'en': 'Web, Mobile'
+    }
+}
+
+# Severity tags and its display names
+SEVERITY_TAGS = {
+    'critical': {
+        'ja': '[CRITICAL]',
+        'en': '[CRITICAL]'
+    },
+    'major': {
+        'ja': '[MAJOR]',
+        'en': '[MAJOR]'
+    },
+    'normal': {
+        'ja': '[NORMAL]',
+        'en': '[NORMAL]'
+    },
+    'minor': {
+        'ja': '[MINOR]',
+        'en': '[MINOR]'
+    }
+}
+
+# Possible targets for implementation examples
+IMPLEMENTATION_TARGETS = {
+    'web': {
+        'ja': 'Web',
+        'en': 'Web'
+    },
+    'android': {
+        'ja': 'Android',
+        'en': 'Android'
+    },
+    'ios': {
+        'ja': 'iOS',
+        'en': 'iOS'
+    }
+}
+
 # Directories
 CWD = os.getcwd()
 DATA_DIR = os.path.join(CWD, 'data')
@@ -107,4 +207,5 @@ def get_static_dest_files(lang):
         'faq_tag_index': os.path.join(dest_dirnames['faq_tags'], FAQ_INDEX_FILENAME),
         'makefile': os.path.join(dest_dirnames['base'], MAKEFILE_FILENAME)
     }
+
 

--- a/tools/yaml2rst/templates/checks/allchecks.rst
+++ b/tools/yaml2rst/templates/checks/allchecks.rst
@@ -15,18 +15,18 @@
 重篤度
    {{ check.severity }}
 関連ガイドライン項目
-{%- for ref in check.gl_refs %}
-   *  {{ ref.category }}： :ref:`{{ ref.glref }}`
+{%- for ref in check.guidelines %}
+   *  {{ ref.category }}： :ref:`{{ ref.guideline }}`
 {%- endfor %}
-{% if check.faqrefs is defined -%}
+{% if check.faqs is defined -%}
 関連FAQ
-{%- for item in check.faqrefs %}
-   *  {{ item }}
+{%- for item in check.faqs %}
+   *  :ref:`faq-{{ item }}`
 {%- endfor %}
 {%- endif %}
-{% if check.inforefs is defined -%}
+{% if check.info_refs is defined -%}
 参考情報
-{%- for item in check.inforefs %}
+{%- for item in check.info_refs %}
    *  {{ item }}
 {%- endfor %}
 {%- endif %}

--- a/tools/yaml2rst/templates/checks/examples-tool.rst
+++ b/tools/yaml2rst/templates/checks/examples-tool.rst
@@ -1,11 +1,11 @@
 {% for ex in examples -%}
-.. _check-example-{{ ex.tool }}-{{ ex.id }}:
+.. _check-example-{{ ex.tool }}-{{ ex.check_id }}:
 
 {% filter make_heading(2) -%}
-:ref:`check-{{ ex.id }}`
+:ref:`check-{{ ex.check_id }}`
 {%- endfilter %}
 
-   {{ ex.check | indent(3) }}
+   {{ ex.check_text | indent(3) }}
 
 {{ ex.technique }}
 {% if ex.note is defined %}

--- a/tools/yaml2rst/templates/checks/implementation.rst
+++ b/tools/yaml2rst/templates/checks/implementation.rst
@@ -3,8 +3,8 @@
 実装方法の例：{{ impl.title }}
 {%- endfilter %}
 
-{% for ex in impl.examples -%}
-{{ ex.platform }}
-   {{ ex.method | indent(3) }}
+{% for method in impl.methods -%}
+{{ method.platform }}
+   {{ method.method | indent(3) }}
 {% endfor %}
 {% endfor %}

--- a/tools/yaml2rst/templates/checks/procedure.rst
+++ b/tools/yaml2rst/templates/checks/procedure.rst
@@ -3,7 +3,7 @@
 チェック手順： {{ proc.platform }}
 {%- endfilter %}
 
-{{ proc.text }}
+{{ proc.procedure }}
 
 {% if proc.techniques is defined -%}
 

--- a/tools/yaml2rst/templates/faq/article-index.rst
+++ b/tools/yaml2rst/templates/faq/article-index.rst
@@ -9,7 +9,7 @@ FAQ記事一覧
 .. toctree::
    :maxdepth: 1
    :titlesonly:
-{% for f in files %}
-   {{ f.id }}
+{% for article in articles %}
+   {{ article.id }}
 {%- endfor %}
 

--- a/tools/yaml2rst/templates/faq/article.rst
+++ b/tools/yaml2rst/templates/faq/article.rst
@@ -33,7 +33,7 @@
 {%- endfilter %}
 
 {% for gl in guidelines -%}
-*  {{ gl.category }}： :ref:`{{ gl.id }}`
+*  {{ gl.category }}： :ref:`{{ gl.guideline }}`
 {% endfor %}
 {%- endif %}
 
@@ -54,7 +54,7 @@
 {%- endfilter %}
 
 {% for i in info -%}
-*  :ref:`{{ i }}`
+*  {{ i }}
 {% endfor %}
 {%- endif %}
 

--- a/tools/yaml2rst/templates/faq/index.rst
+++ b/tools/yaml2rst/templates/faq/index.rst
@@ -29,7 +29,7 @@
 FAQ記事一覧
 {%- endfilter %}
 
-{% for f in files -%}
-*  :ref:`faq-{{ f.id }}` （{{ f.updated_year }}年{{ f.updated_month }}月{{ f.updated_day }}日更新）
+{% for article in articles -%}
+*  :ref:`faq-{{ article.id }}` （{{ article.updated_year }}年{{ article.updated_month }}月{{ article.updated_day }}日更新）
 {% endfor %}
 

--- a/tools/yaml2rst/templates/gl-category.rst
+++ b/tools/yaml2rst/templates/gl-category.rst
@@ -22,12 +22,12 @@
 参考情報
 {%- for item in gl.info %}
    *  {{ item }}
-{% endfor -%}
+{%- endfor %}
 {%- endif %}
-{%- if gl.faqrefs is defined -%}
+{% if gl.faqs is defined -%}
 関連FAQ
-{%- for item in gl.faqrefs %}
-   *  {{ item }}
+{%- for item in gl.faqs %}
+   *  :ref:`faq-{{ item }}`
 {% endfor %}
 {%- endif %}
 
@@ -55,8 +55,6 @@
 {% if check.procedures is defined %}
 {% include 'checks/procedure.rst' %}
 {% endif %}
-
 {%- endfor %}
-
 {% endfor %}
 

--- a/tools/yaml2rst/templates/gl-category.rst
+++ b/tools/yaml2rst/templates/gl-category.rst
@@ -14,8 +14,8 @@
 {%- for sc in gl.scs %}
    *  達成基準{{ sc.sc }}(レベル{{ sc.sc_level }})：
 
-      -  {{ sc.sc_en }}
-      -  {{ sc.sc_ja }}
+      -  `{{ sc.sc_en_title }} <{{ sc.sc_en_url }}>`_
+      -  `{{ sc.sc_ja_title }} <{{ sc.sc_ja_url }}>`_
 
 {% endfor -%}
 {% if gl.info is defined -%}

--- a/tools/yaml2rst/templates/incfiles.mk
+++ b/tools/yaml2rst/templates/incfiles.mk
@@ -15,7 +15,7 @@ ALL_INC_FILES = {{ info_to_gl_target }} {{ info_to_faq_target }} {{ guideline_ca
 {{ faq_index_target }}: {{ faq_yaml }}
 	@$(YAML2RST) $@
 
-{% for item in other_deps %}
-{{ item.dep }}
+{% for item in depends %}
+{{ item.target }}: {{ item.depends }}
 	@$(YAML2RST) {{ item.target }}
 {% endfor %}

--- a/tools/yaml2rst/templates/info_to_faq.rst
+++ b/tools/yaml2rst/templates/info_to_faq.rst
@@ -3,6 +3,6 @@
 {%- endfilter %}
 
 {% for faq in faqs -%}
-*  :ref:`{{ faq.label }}`
+*  :ref:`faq-{{ faq }}`
 {% endfor %}
 

--- a/tools/yaml2rst/templates/info_to_gl.rst
+++ b/tools/yaml2rst/templates/info_to_gl.rst
@@ -3,6 +3,6 @@
 {%- endfilter %}
 
 {% for gl in guidelines -%}
-*  {{ gl.category }}： :ref:`{{ gl.id }}`
+*  {{ gl.category }}： :ref:`{{ gl.guideline }}`
 {% endfor %}
 

--- a/tools/yaml2rst/templates/priority-diff.rst
+++ b/tools/yaml2rst/templates/priority-diff.rst
@@ -2,6 +2,6 @@
    :widths: auto
    :header: "達成基準","原文","日本語訳","見直し前","見直し後"
 {% for item in diffs %}
-   "{{ item.sc }}","{{ item.sc_en }}","{{ item.sc_ja }}","{{ item.level }}","{{ item.LocalLevel }}"
+   "{{ item.sc }}","`{{ item.sc_en_title }} <{{ item.sc_en_url }}>`_","`{{ item.sc_ja_title }} <{{ item.sc_ja_url }}>`_","{{ item.level }}","{{ item.LocalLevel }}"
 {%- endfor %}
 

--- a/tools/yaml2rst/templates/priority-diff.rst
+++ b/tools/yaml2rst/templates/priority-diff.rst
@@ -2,6 +2,6 @@
    :widths: auto
    :header: "達成基準","原文","日本語訳","見直し前","見直し後"
 {% for item in diffs %}
-   "{{ item.sc }}","`{{ item.sc_en_title }} <{{ item.sc_en_url }}>`_","`{{ item.sc_ja_title }} <{{ item.sc_ja_url }}>`_","{{ item.level }}","{{ item.LocalLevel }}"
+   "{{ item.sc }}","`{{ item.sc_en_title }} <{{ item.sc_en_url }}>`_","`{{ item.sc_ja_title }} <{{ item.sc_ja_url }}>`_","{{ item.sc_level }}","{{ item.LocalLevel }}"
 {%- endfor %}
 

--- a/tools/yaml2rst/templates/wcag21-mapping.rst
+++ b/tools/yaml2rst/templates/wcag21-mapping.rst
@@ -3,8 +3,8 @@
    :header: "達成基準","原文","日本語訳","レベル","対応するガイドライン"
 {% for item in mapping %}
    "{{ item.sc }}","`{{ item.sc_en_title }} <{{ item.sc_en_url }}>`_","`{{ item.sc_ja_title }} <{{ item.sc_ja_url }}>`_","{{ item.level }}","
-{%- for gl in item.gls %}
-   *  {{ gl.category }}： :ref:`{{ gl.gl }}`
+{%- for gl in item.guidelines %}
+   *  {{ gl.category }}： :ref:`{{ gl.guideline }}`
 {%- endfor %}"
 {%- endfor %}
 

--- a/tools/yaml2rst/templates/wcag21-mapping.rst
+++ b/tools/yaml2rst/templates/wcag21-mapping.rst
@@ -2,6 +2,9 @@
    :widths: auto
    :header: "達成基準","原文","日本語訳","レベル","対応するガイドライン"
 {% for item in mapping %}
-   "{{ item.sc }}","{{ item.sc_en }}","{{ item.sc_ja }}","{{ item.level }}","{{ item.gls }}"
+   "{{ item.sc }}","`{{ item.sc_en_title }} <{{ item.sc_en_url }}>`_","`{{ item.sc_ja_title }} <{{ item.sc_ja_url }}>`_","{{ item.level }}","
+{%- for gl in item.gls %}
+   *  {{ gl.category }}： :ref:`{{ gl.gl }}`
+{%- endfor %}"
 {%- endfor %}
 

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -86,14 +86,12 @@ def main():
     build_examples = []
 
     if not args.no_check:
+        common_schema_path = os.path.join(os.getcwd(), SCHEMA_SRCDIR, COMMON_SCHEMA)
         try:
-            with open(os.path.join(os.getcwd(), SCHEMA_SRCDIR, COMMON_SCHEMA)) as f:
-                common_schema = json.load(f)
+            file_content = read_file_content(common_schema_path)
+            common_schema = json.loads(file_content)
         except Exception as e:
-            print(f'Exception occurred while reading {COMMON_SCHEMA}...', file=sys.stderr)
-            print(e, file=sys.stderr)
-            sys.exit(1)
-
+            handle_file_error(e, common_schema_path)
         schema_path = 'file://{}/'.format(os.path.join(os.getcwd(), SCHEMA_SRCDIR))
         resolver = RefResolver(schema_path, common_schema)
 
@@ -124,28 +122,22 @@ def main():
         check_duplicate_values(faqs, 'sortKey', 'FAQ sortKey')
 
     try:
-        with open(WCAG_SC) as f:
-            wcag_sc = json.load(f)
+        file_content = read_file_content(WCAG_SC)
+        wcag_sc = json.loads(file_content)
     except Exception as e:
-        print(f'Exception occurred while reading {WCAG_SC}...', file=sys.stderr)
-        print(e, file=sys.stderr)
-        sys.exit(1)
+        handle_file_error(e, WCAG_SC)
 
     try:
-        with open(GUIDELINE_CATEGORIES) as f:
-            category_names = json.load(f)
+        file_content = read_file_content(GUIDELINE_CATEGORIES)
+        category_names = json.loads(file_content)
     except Exception as e:
-        print(f'Exception occurred while reading {GUIDELINE_CATEGORIES}...', file=sys.stderr)
-        print(e, file=sys.stderr)
-        sys.exit(1)
+        handle_file_error(e, GUIDELINE_CATEGORIES)
 
     try:
-        with open(FAQ_TAGS) as f:
-            faq_tags = json.load(f)
+        file_content = read_file_content(FAQ_TAGS)
+        faq_tags = json.loads(file_content)
     except Exception as e:
-        print(f'Exception occurred while reading {FAQ_TAGS}...', file=sys.stderr)
-        print(e, file=sys.stderr)
-        sys.exit(1)
+        handle_file_error(e, FAQ_TAGS)
 
     for sc in wcag_sc:
         wcag_sc[sc]['gls'] = []
@@ -509,12 +501,10 @@ def main():
 
     if build_all or MISCDEFS_PATH in targets:
         try:
-            with open(INFO_SRC, encoding='utf-8') as f:
-                info_links = json.load(f)
+            file_content = read_file_content(INFO_SRC)
+            info_links = json.loads(file_content)
         except Exception as e:
-            print(f'Exception occurred while reading {INFO_SRC}...', file=sys.stderr)
-            print(e, file=sys.stderr)
-            sys.exit(1)
+            handle_file_error(e, INFO_SRC)
 
         external_info_links = []
         for link in info_links:
@@ -650,6 +640,33 @@ def ls_dir(dir):
         for f in fs:
             files.append(os.path.join(currentDir, f))
     return files
+
+def read_file_content(file_path):
+    """
+    Read and return the content of a file.
+
+    Args:
+        file_path: Path to the file.
+
+    Returns:
+        The content of the file.
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as file:
+            return file.read()
+    except Exception as e:
+        raise e
+
+def handle_file_error(e, file_path):
+    """
+    Handle file-related errors.
+
+    Args:
+        e: The exception object.
+        file_path: Path to the file that caused the error.
+    """
+    print(f"Error with file {file_path}: {e}", file=sys.stderr)
+    sys.exit(1)
 
 def read_yaml_file(file):
     try:
@@ -820,7 +837,7 @@ def load_templates(template_env):
         'makefile': MAKEFILE_FILENAME,
         'miscdefs': 'misc-defs.txt'
     }
-    
+
     templates = {name: template_env.get_template(filename) for name, filename in template_filenames.items()}
     return templates
 

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -105,11 +105,6 @@ def main():
     except Exception as e:
         handle_file_error(e, MISC_INFO_SRCFILES['faq_tags'])
 
-    for sc in wcag_sc:
-        wcag_sc[sc]['gls'] = []
-        wcag_sc[sc]['en']['linkCode'] = f'`{wcag_sc[sc]["en"]["title"]} <{wcag_sc[sc]["en"]["url"]}>`_'
-        wcag_sc[sc]['ja']['linkCode'] = f'`{wcag_sc[sc]["ja"]["title"]} <{wcag_sc[sc]["ja"]["url"]}>`_'
-
     category_pages = {}
     guideline_category_target = []
     for cat in category_names:
@@ -124,6 +119,8 @@ def main():
     for gl in guidelines:
         gl_categories[gl['id']] = category_names[gl['category']][LANG]
         for sc in gl['sc']:
+            if not 'gls' in wcag_sc[sc]:
+                wcag_sc[sc]['gls'] = []
             wcag_sc[sc]['gls'].append(gl['id'])
 
         if not 'info' in gl:
@@ -314,8 +311,10 @@ def main():
         for sc in gl['sc']:
             gl_str['scs'].append({
                 'sc': sc,
-                'sc_en': wcag_sc[sc]['en']['linkCode'],
-                'sc_ja': wcag_sc[sc]['ja']['linkCode'],
+                'sc_en_title': wcag_sc[sc]['en']['title'],
+                'sc_en_url': wcag_sc[sc]['en']['url'],
+                'sc_ja_title': wcag_sc[sc]['ja']['title'],
+                'sc_ja_url': wcag_sc[sc]['ja']['url'],
                 'sc_level': wcag_sc[sc]['level']
             })
 
@@ -430,18 +429,22 @@ def main():
     if build_all or STATIC_FILES['wcag21mapping'] in targets:
         sc_mapping = []
         for sc in wcag_sc:
-            if len(wcag_sc[sc]['gls']) == 0:
+            if not 'gls' in wcag_sc[sc]:
                 continue
             gls = []
             for gl in wcag_sc[sc]['gls']:
-                gls.append(f'*  {gl_categories[gl]}： :ref:`{gl}`')
-            gls_str = '\n   '.join(gls)
+                gls.append({
+                    'category': gl_categories[gl],
+                    'gl': gl
+                })
             mapping = {
                 'sc': sc,
-                'sc_en': wcag_sc[sc]['en']['linkCode'],
-                'sc_ja': wcag_sc[sc]['ja']['linkCode'],
+                'sc_en_title': wcag_sc[sc]['en']['title'],
+                'sc_en_url': wcag_sc[sc]['en']['url'],
+                'sc_ja_title': wcag_sc[sc]['ja']['title'],
+                'sc_ja_url': wcag_sc[sc]['ja']['url'],
                 'level': wcag_sc[sc]['level'],
-                'gls': gls_str
+                'gls': gls
             }
             sc_mapping.append(mapping)
         write_rst(templates['wcag21mapping'], {'mapping': sc_mapping}, STATIC_FILES['wcag21mapping'])
@@ -453,8 +456,10 @@ def main():
                 continue
             diff = {
                 'sc': sc,
-                'sc_en': wcag_sc[sc]['en']['linkCode'],
-                'sc_ja': wcag_sc[sc]['ja']['linkCode'],
+                'sc_en_title': wcag_sc[sc]['en']['title'],
+                'sc_en_url': wcag_sc[sc]['en']['url'],
+                'sc_ja_title': wcag_sc[sc]['ja']['title'],
+                'sc_ja_url': wcag_sc[sc]['ja']['url'],
                 'level': wcag_sc[sc]['level'],
                 'LocalLevel': wcag_sc[sc]['localPriority']
             }

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -9,8 +9,8 @@ from jsonschema import validate, ValidationError, RefResolver
 import argparse
 from jinja2 import Template, Environment, FileSystemLoader
 import datetime
+from config import AVAILABLE_LANGUAGES
 
-LANG = 'ja'
 GUIDELINES_SRCDIR = 'data/yaml/gl'
 INFO_SRC = 'data/json/info.json'
 CHECKS_SRCDIR = 'data/yaml/checks'
@@ -79,6 +79,7 @@ def main():
     settings = process_arguments(args)
     build_all = settings.get('build_all')
     targets = settings.get('targets')
+    LANG = settings.get('lang')
 
     template_env = setup_template_environment()
     templates = load_templates(template_env)
@@ -774,6 +775,7 @@ def check_duplicate_values(lst, key, dataset):
 def parse_args():
     parser = argparse.ArgumentParser(description="Process YAML files into rst files for the a11y-guidelines.")
     parser.add_argument('--no-check', action='store_true', help='Do not run various checks of YAML files')
+    parser.add_argument('--lang', '-l', type=str, choices=AVAILABLE_LANGUAGES, default='ja', help=f'the language of the output file ({" ".join(AVAILABLE_LANGUAGES)})')
     parser.add_argument('files', nargs='*', help='Filenames')
     return parser.parse_args()
 
@@ -789,7 +791,8 @@ def process_arguments(args):
     """
     settings = {
         'build_all': not args.files,
-        'targets': args.files if args.files else []
+        'targets': args.files if args.files else [],
+        'lang': args.lang
     }
 
     # 例：新しいオプション 'verbose' の処理

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -4,39 +4,12 @@ import re
 import yaml
 import json
 import unicodedata
-import copy
 from jsonschema import validate, ValidationError, RefResolver
 import argparse
 from jinja2 import Template, Environment, FileSystemLoader
 import datetime
-from config import AVAILABLE_LANGUAGES, SRCDIR, SCHEMA_FILENAMES, COMMON_SCHEMA_PATH, TEMPLATE_DIR, TEMPLATE_FILENAMES, MISC_INFO_SRCFILES, get_dest_dirnames, get_static_dest_files
-
-# Values which needs to be changed if there are some changes in the checklist/item structure:
-CHECK_TOOLS = {
-    'nvda': 'NVDA',
-    'macos-vo': 'macOS VoiceOver',
-    'axe': 'axe DevTools',
-    'ios-vo': 'iOS VoiceOver',
-    'android-tb': 'Android TalkBack',
-    'keyboard': 'キーボード操作',
-    'misc': 'その他のツール'
-}
-IMPLEMENTATION_NAMES = {
-    'web': 'Web',
-    'ios': 'iOS',
-    'android': 'Android'
-}
-TARGET_NAMES = {
-    'design': 'デザイン',
-    'code': 'コード',
-    'product': 'プロダクト'
-}
-PLATFORM_NAMES = {
-    'web': 'Web',
-    'mobile': 'モバイル',
-    'general': 'Web、モバイル'
-}
-
+from config import AVAILABLE_LANGUAGES, CHECK_TOOLS, SRCDIR, SCHEMA_FILENAMES, COMMON_SCHEMA_PATH, TEMPLATE_DIR, TEMPLATE_FILENAMES, MISC_INFO_SRCFILES, get_dest_dirnames, get_static_dest_files
+from a11y_guidelines import Category, WCAG_SC, InfoRef, Guideline, Check, FAQ, FAQ_Tag, CheckTool
 
 def main():
     args = parse_args()
@@ -50,8 +23,6 @@ def main():
     template_env = setup_template_environment()
     templates = load_templates(template_env)
 
-    build_examples = []
-
     if not args.no_check:
         try:
             file_content = read_file_content(COMMON_SCHEMA_PATH)
@@ -61,414 +32,170 @@ def main():
         schema_path = f'file://{SRCDIR["schema"]}/'
         resolver = RefResolver(schema_path, common_schema)
 
-    files = ls_dir(SRCDIR['guidelines'])
-    guidelines = []
-    for f in files:
-        guidelines.append(process_yaml_file(f, SRCDIR['schema'], SCHEMA_FILENAMES['guidelines'], args.no_check, resolver))
+    data = {
+        'guidelines': [],
+        'checks': [],
+        'faqs': [],
+        'faq_tags': [],
+        'categories': [],
+        'wcag_sc': []
+    }
 
-    guidelines = sorted(guidelines, key=lambda x: x['sortKey'])
+    makefile_vars = {
+        'all_checks_target': STATIC_FILES['all_checks'],
+        'faq_index_target': " ".join([STATIC_FILES[key] for key in ['faq_index', 'faq_tag_index', 'faq_article_index']]),
+        'wcag21mapping_target': STATIC_FILES['wcag21mapping'],
+        'priority_diff_target': STATIC_FILES['priority_diff'],
+        'miscdefs_target': STATIC_FILES['miscdefs'],
+        'wcag_sc': MISC_INFO_SRCFILES['wcag_sc'],
+        'info_src': MISC_INFO_SRCFILES['info'],
+        'gl_yaml': '',
+        'check_yaml': '',
+        'faq_yaml': ''
+    }
+    makefile_vars_list = {
+        'guideline_category_target': [],
+        'check_example_target': [],
+        'faq_article_target': [],
+        'faq_tagpage_target': [],
+        'info_to_gl_target': [],
+        'info_to_faq_target': [],
+    }
 
+    # Setup CheckTool instances
+    for tool_id, tool_names in CHECK_TOOLS.items():
+        CheckTool(tool_id, tool_names)
+    
+    # Set up check instances
     files = ls_dir(SRCDIR['checks'])
-    checks = []
-    for f in files:
-        checks.append(process_yaml_file(f, SRCDIR['schema'], SCHEMA_FILENAMES['checks'], args.no_check, resolver))
-
-    files = ls_dir(SRCDIR['faq'])
-    faqs = []
-    for f in files:
-        faqs.append(process_yaml_file(f, SRCDIR['schema'], SCHEMA_FILENAMES['faq'], args.no_check, resolver))
-
-    faqs = sorted(faqs, key=lambda x: x['sortKey'])
-
+    makefile_vars['check_yaml'] = ' '.join(files)
+    data['checks'] = [process_yaml_file(f, SRCDIR['schema'], SCHEMA_FILENAMES['checks'], args.no_check, resolver) for f in files]
     if not args.no_check:
-        check_duplicate_values(guidelines, 'id', 'Guideline ID')
-        check_duplicate_values(guidelines, 'sortKey', 'Guideline sortKey')
-        check_duplicate_values(checks, 'id', 'Check ID')
-        check_duplicate_values(faqs, 'id', 'FAQ ID')
-        check_duplicate_values(faqs, 'sortKey', 'FAQ sortKey')
-
-    try:
-        file_content = read_file_content(MISC_INFO_SRCFILES['wcag_sc'])
-        wcag_sc = json.loads(file_content)
-    except Exception as e:
-        handle_file_error(e, MISC_INFO_SRCFILES['wcag_sc'])
-
+        check_duplicate_values(data['checks'], 'id', 'Check ID')
+    for check in data['checks']:
+        Check(check)
+    
+    # Set up guideline category instances
     try:
         file_content = read_file_content(MISC_INFO_SRCFILES['gl_categories'])
-        category_names = json.loads(file_content)
+        data['categories'] = json.loads(file_content)
     except Exception as e:
         handle_file_error(e, MISC_INFO_SRCFILES['gl_categories'])
+    for id, names in data['categories'].items():
+        Category(id, names)
 
+    # Set up WCAG SC instances
+    try:
+        file_content = read_file_content(MISC_INFO_SRCFILES['wcag_sc'])
+        data['wcag_sc'] = json.loads(file_content)
+    except Exception as e:
+        handle_file_error(e, MISC_INFO_SRCFILES['wcag_sc'])
+    for sc in data['wcag_sc'].values():
+        WCAG_SC(sc)
+    
+    # Set up guideline instances
+    files = ls_dir(SRCDIR['guidelines'])
+    makefile_vars['gl_yaml'] = ' '.join(files)
+    data['guidelines'] = [process_yaml_file(f, SRCDIR['schema'], SCHEMA_FILENAMES['guidelines'], args.no_check, resolver) for f in files]
+    if not args.no_check:
+        check_duplicate_values(data['guidelines'], 'id', 'Guideline ID')
+        check_duplicate_values(data['guidelines'], 'sortKey', 'Guideline sortKey')
+    for gl in data['guidelines']:
+        Guideline(gl)
+
+    # Set up FAQ tag instances
     try:
         file_content = read_file_content(MISC_INFO_SRCFILES['faq_tags'])
-        faq_tags = json.loads(file_content)
+        data['faq_tags'] = json.loads(file_content)
     except Exception as e:
         handle_file_error(e, MISC_INFO_SRCFILES['faq_tags'])
+    for id, names in data['faq_tags'].items():
+        FAQ_Tag(id, names)
 
-    category_pages = {}
-    guideline_category_target = []
-    for cat in category_names:
-        category_pages[cat] = {
-            'guidelines': [],
-            'dependency': []
-        }
-        guideline_category_target.append(os.path.join(DEST_DIRS['guidelines'], f'{cat}.rst'))
-
-    gl_categories = {}
-    info_to_gl = {}
-    for gl in guidelines:
-        gl_categories[gl['id']] = category_names[gl['category']][LANG]
-        for sc in gl['sc']:
-            if not 'gls' in wcag_sc[sc]:
-                wcag_sc[sc]['gls'] = []
-            wcag_sc[sc]['gls'].append(gl['id'])
-
-        if not 'info' in gl:
-            continue
-        for info in gl['info']:
-            if re.match(r'(https?://|\|.+\|)', info):
-                continue
-            if info not in info_to_gl:
-                info_to_gl[info] = []
-            info_to_gl[info].append({
-                'id': gl['id'],
-                'category': gl_categories[gl['id']],
-                'sortKey': gl['sortKey']
-            })
-
-        for faq in faqs:
-            if not 'guidelines' in faq:
-                continue
-            if gl['id'] in faq['guidelines']:
-                if 'faqrefs' not in gl:
-                    gl['faq_ref'] = []
-                gl['faq_ref'].append(faq["id"])
-
-    allchecks = []
-    check_examples = {}
-    for key in CHECK_TOOLS:
-        check_examples[key] = []
-
-    for check in sorted(checks, key=lambda x: x['id']):
-        if f'data/yaml/checks/{check["target"]}/{check["id"]}.yaml' != check['src_path']:
-            raise Exception(f'The file path does not match the ID and/or the target in {check["src_path"]}')
-
-        check['severity'] = f"[{check['severity'].upper()}]"
-        check['gl_ref'] = []
-        check['info'] = []
-        for gl in guidelines:
-            if check["id"] in gl['checks']:
-                check['gl_ref'].append(gl["id"])
-                if 'info' in gl:
-                    check['info'].extend(gl['info'])
-
-        if len(check['gl_ref']) == 0:
-            raise Exception(f'The check {check["id"]} is not referred to from any guideline.')
-
-        check['faq_ref'] = []
-        for faq in faqs:
-            if not 'checks' in faq:
-                continue
-            if check["id"] in faq['checks']:
-                check['faq_ref'].append(faq["id"])
-
-        check_str = {
-            'target': TARGET_NAMES[check['target']],
-            'platform': '、'.join(list(map(lambda item: PLATFORM_NAMES[item], check['platform']))),
-            'id': check['id'],
-            'severity': check['severity'],
-            'check': check['check'][LANG],
-        }
-        if len(check['info']) > 0:
-            check['info'] = uniq(check['info'])
-            check_str['inforefs'] = []
-            for info in check['info']:
-                if re.match(r'(https?://|\|.+\|)', info):
-                    check_str['inforefs'].append(info)
-                else:
-                    check_str['inforefs'].append(f':ref:`{info}`')
-
-        if len(check['faq_ref']) > 0:
-            check_str['faqrefs'] = []
-            for faq in check['faq_ref']:
-                check_str['faqrefs'].append(f':ref:`faq-{faq}`')
-
-        check_str['gl_refs'] = []
-        for ref in check['gl_ref']:
-            check_str['gl_refs'].append({
-                'category': gl_categories[ref],
-                'glref': ref
-                })
-
-        if check['target'] == 'code' and 'implementations' in check:
-            check_str['implementations'] = []
-            for detail in check['implementations']:
-                implementation = {
-                    'title': detail['title'],
-                    'examples': []
-                }
-
-                for impl in detail['methods']:
-                    implementation['examples'].append({
-                        'platform': IMPLEMENTATION_NAMES[impl['platform']],
-                        'method': impl['method']
-                    })
-                check_str['implementations'].append(implementation)
-        elif check['target'] == 'product' and 'procedures' in check:
-            check_str['procedures'] = []
-            for procedure in check['procedures']:
-                procedure_str_obj = {}
-                procedure_str_obj = {
-                    'platform': PLATFORM_NAMES[procedure['platform']],
-                    'text': procedure['procedure'][LANG]
-                }
-
-                if 'techniques' in procedure:
-                    procedure_str_obj['techniques'] = []
-                    if 'checkTools' not in check:
-                        check['checkTools'] = []
-                    for technique in procedure['techniques']:
-                        if technique['tool'] in CHECK_TOOLS:
-                            tool_basename = technique['tool']
-                            tool_display_name = CHECK_TOOLS[technique['tool']]
-                        else:
-                            tool_basename = 'misc'
-                            tool_display_name = technique['tool']
-
-                        str_obj = {
-                            'tool_display_name': tool_display_name,
-                            'technique': technique['technique'][LANG],
-                            'tool': tool_basename,
-                            'id': check['id'],
-                            'check': check['check'][LANG],
-                        }
-                        if 'note' in technique:
-                            str_obj['note'] = technique['note'][LANG]
-                        if 'YouTube' in technique:
-                            str_obj['YouTube'] = technique['YouTube']
-                        check['checkTools'].append(tool_basename)
-                        procedure_str_obj['techniques'].append(str_obj)
-                        check_examples[tool_basename].append(str_obj)
-
-                check_str['procedures'].append(procedure_str_obj)
-
-        allchecks.append(check_str)
-        check['check_str'] = check_str
-
-    info_to_faq = {}
-    for faq in faqs:
-        if not 'info' in faq:
-            continue
-        for info in faq['info']:
-            if not info in info_to_faq:
-                info_to_faq[info] = []
-            info_to_faq[info].append({
-                'id': faq['id'],
-                'label': f'faq-{faq["id"]}',
-                'sortKey': faq['sortKey']
-            })
-
-    for gl in guidelines:
-        category_pages[gl['category']]['dependency'].append(gl['src_path'])
-        gl_str = {
-            'title': gl['title'][LANG],
-            'intent': gl['intent'][LANG],
-            'id': gl['id'],
-            'platform': '、'.join(list(map(lambda item: PLATFORM_NAMES[item], gl['platform']))),
-            'guideline': gl['guideline'][LANG]
-        }
-
-        if 'info' in gl:
-            gl_str['info'] = []
-            for ref in gl['info']:
-                if re.match(r'(https?://|\|.+\|)', ref):
-                    gl_str['info'].append(ref)
-                else:
-                    gl_str['info'].append(f':ref:`{ref}`')
-
-        if 'faq_ref' in gl:
-            gl_str['faqrefs'] = []
-            for faq in gl['faq_ref']:
-                gl_str['faqrefs'].append(f':ref:`faq-{faq}`')
-
-        gl_str['checks'] = []
-        gl['examples'] = []
-        for check in gl['checks']:
-            _check = [x for x in checks if x["id"] == check][0]
-            _check_str = copy.deepcopy(_check['check_str'])
-            if 'checkTools' in _check:
-                gl['examples'].extend(list(_check['checkTools']))
-            if 'procedures' in _check:
-                for i, proc in enumerate(_check['procedures']):
-                    if proc['platform'] == 'general' or proc['platform'] in gl['platform']:
-                        continue
-                    del _check_str['procedures'][i]
-
-            gl_str['checks'].append(_check_str)
-            category_pages[gl['category']]['dependency'].append(_check['src_path'])
-
-        gl_str['scs'] = []
-        for sc in gl['sc']:
-            gl_str['scs'].append({
-                'sc': sc,
-                'sc_en_title': wcag_sc[sc]['en']['title'],
-                'sc_en_url': wcag_sc[sc]['en']['url'],
-                'sc_ja_title': wcag_sc[sc]['ja']['title'],
-                'sc_ja_url': wcag_sc[sc]['ja']['url'],
-                'sc_level': wcag_sc[sc]['level']
-            })
-
-        category_pages[gl['category']]['guidelines'].append(gl_str)
-        if len(gl['examples']) > 0:
-            build_examples.extend(gl['examples'])
-        build_examples = uniq(build_examples)
+    # Set up FAQ instances
+    files = ls_dir(SRCDIR['faq'])
+    makefile_vars['faq_yaml'] = ' '.join(files)
+    data['faqs'] = [process_yaml_file(f, SRCDIR['schema'], SCHEMA_FILENAMES['faq'], args.no_check, resolver) for f in files]
+    if not args.no_check:
+        check_duplicate_values(data['faqs'], 'id', 'FAQ ID')
+        check_duplicate_values(data['faqs'], 'sortKey', 'FAQ sortKey')
+    for faq in data['faqs']:
+        FAQ(faq)
 
     os.makedirs(DEST_DIRS['guidelines'], exist_ok=True)
-    for cat in category_pages:
-        filename = f'{cat}.rst'
+    for cat in Category.list_all():
+        filename = f'{cat.id}.rst'
         destfile = os.path.join(DEST_DIRS['guidelines'], filename)
         if build_all or destfile in targets:
-            write_rst(templates['category_page'], {'guidelines': category_pages[cat]['guidelines']}, destfile)
-
-    os.makedirs(DEST_DIRS['info2gl'], exist_ok=True)
-    for info in info_to_gl:
-        filename = f'{info}.rst'
-        destfile = os.path.join(os.getcwd(), DEST_DIRS['info2gl'], filename)
-        if build_all or destfile in targets:
-            write_rst(templates['info_to_gl'], {'guidelines': sorted(info_to_gl[info], key=lambda x: x['sortKey'])}, destfile)
-
-    os.makedirs(DEST_DIRS['info2faq'], exist_ok=True)
-    for info in info_to_faq:
-        filename = f'{info}.rst'
-        destfile = os.path.join(os.getcwd(), DEST_DIRS['info2faq'], filename)
-        if build_all or destfile in targets:
-            write_rst(templates['info_to_faq'], {'faqs': sorted(info_to_faq[info], key=lambda x: x['sortKey'])}, destfile)
-
-    os.makedirs(DEST_DIRS['faq_articles'], exist_ok=True)
-    faq_articles = []
-    faq_tagpages = {}
-    for faq in faqs:
-        faq_updated = datetime.datetime.fromisoformat(faq['updated'])
-        faq_articles.append({
-            'id': faq['id'],
-            'sortKey': faq['sortKey'],
-            'updated': faq_updated,
-            'updated_year': faq_updated.year,
-            'updated_month': faq_updated.month,
-            'updated_day': faq_updated.day
-        })
-        article_filename = f'{faq["id"]}.rst'
-        destfile = os.path.join(DEST_DIRS['faq_articles'], article_filename)
-        if build_all or destfile in targets:
-            faq_obj = {
-                'id': faq['id'],
-                'title': faq['title'][LANG],
-                'updated_year': faq_updated.year,
-                'updated_month': faq_updated.month,
-                'updated_day': faq_updated.day,
-                'tags': faq['tags'],
-                'problem': faq['problem'][LANG],
-                'solution': faq['solution'][LANG],
-                'explanation': faq['explanation'][LANG]
-            }
-            if 'checks' in faq:
-                faq_obj['checks'] = []
-                for c in faq['checks']:
-                    faq_obj['checks'].append({
-                        'id': c,
-                        'check': [x for x in checks if x["id"] == c][0]['check'][LANG],
-                    })
-            if 'info' in faq:
-                faq_obj['info'] = faq['info']
-            if 'guidelines' in faq:
-                faq_obj['guidelines'] = []
-                for gl in faq['guidelines']:
-                    faq_obj['guidelines'].append({
-                        'id': gl,
-                        'category': gl_categories[gl]
-                    })
-            faq['destpath'] = os.path.join(DEST_DIRS['faq_articles'], article_filename)
-            write_rst(templates['faq_article'], faq_obj, destfile)
-
-        for tag in faq['tags']:
-            try:
-                if not tag in faq_tags:
-                    raise ValueError(f'FAQ tag {tag} in {faq["id"]} is not defined in {MISC_INFO_SRCFILES["faq_tags"]}')
-            except ValueError as e:
-                print(e, file=sys.stderr)
-                sys.exit(1)
-            if not tag in faq_tagpages:
-                faq_tagpages[tag] = {
-                    'tag': tag,
-                    'label': faq_tags[tag][LANG],
-                    'articles': [],
-                    'count': 0
-                }
-            faq_tagpages[tag]['articles'].append(faq["id"])
-            faq_tagpages[tag]['count'] += 1
-
-    faq_tagpage_list = sorted(faq_tagpages.values(), key=lambda x: x['label'])
-
-    os.makedirs(DEST_DIRS['faq_tags'], exist_ok=True)
-    for page in faq_tagpage_list:
-        filename = f'{page["tag"]}.rst'
-        destfile = os.path.join(DEST_DIRS['faq_tags'], filename)
-        if build_all or destfile in targets:
-            write_rst(templates['faq_tagpage'], page, destfile)
-
-    if build_all or STATIC_FILES['faq_index'] in targets:
-        write_rst(templates['faq_index'], {'files': sorted(faq_articles, key=lambda x: x['updated'], reverse=True), 'tags': faq_tagpage_list}, STATIC_FILES['faq_index'])
-
-    if build_all or STATIC_FILES['faq_tag_index'] in targets:
-        write_rst(templates['faq_tag_index'], {'tags': faq_tagpage_list}, STATIC_FILES['faq_tag_index'])
-
-    if build_all or STATIC_FILES['FAQ_ARTICLE_INDEX_PATH'] in targets:
-        write_rst(templates['faq_article_index'], {'files': sorted(faq_articles, key=lambda x: x['sortKey'])}, STATIC_FILES['faq_article_index'])
-
-    os.makedirs(DEST_DIRS['misc'], exist_ok=True)
-    if build_all or STATIC_FILES['wcag21mapping'] in targets:
-        sc_mapping = []
-        for sc in wcag_sc:
-            if not 'gls' in wcag_sc[sc]:
-                continue
-            gls = []
-            for gl in wcag_sc[sc]['gls']:
-                gls.append({
-                    'category': gl_categories[gl],
-                    'gl': gl
-                })
-            mapping = {
-                'sc': sc,
-                'sc_en_title': wcag_sc[sc]['en']['title'],
-                'sc_en_url': wcag_sc[sc]['en']['url'],
-                'sc_ja_title': wcag_sc[sc]['ja']['title'],
-                'sc_ja_url': wcag_sc[sc]['ja']['url'],
-                'level': wcag_sc[sc]['level'],
-                'gls': gls
-            }
-            sc_mapping.append(mapping)
-        write_rst(templates['wcag21mapping'], {'mapping': sc_mapping}, STATIC_FILES['wcag21mapping'])
-
-    if build_all or STATIC_FILES['priority_diff'] in targets:
-        diffs = []
-        for sc in wcag_sc:
-            if wcag_sc[sc]['level'] == wcag_sc[sc]['localPriority']:
-                continue
-            diff = {
-                'sc': sc,
-                'sc_en_title': wcag_sc[sc]['en']['title'],
-                'sc_en_url': wcag_sc[sc]['en']['url'],
-                'sc_ja_title': wcag_sc[sc]['ja']['title'],
-                'sc_ja_url': wcag_sc[sc]['ja']['url'],
-                'level': wcag_sc[sc]['level'],
-                'LocalLevel': wcag_sc[sc]['localPriority']
-            }
-            diffs.append(diff)
-        write_rst(templates['priority_diff'], {'diffs': diffs}, STATIC_FILES['priority_diff'])
+            gl_object = [gl.template_object(LANG) for gl in cat.get_guidelines()]
+            write_rst(templates['category_page'], {'lang': LANG, 'guidelines': gl_object}, destfile)
 
     os.makedirs(DEST_DIRS['checks'], exist_ok=True)
     if build_all or STATIC_FILES['all_checks'] in targets:
+        allchecks = Check.template_object_all(LANG)
         write_rst(templates['allchecks_text'], {'allchecks': allchecks}, STATIC_FILES['all_checks'])
+
+    for tool in CheckTool.list_all():
+        filename = f'examples-{tool.id}.rst'
+        destfile = os.path.join(DEST_DIRS['checks'], filename)
+        if build_all or destfile:
+            write_rst(templates['tool_example'], tool.example_template_object(LANG), destfile)
+        
+    os.makedirs(DEST_DIRS['faq_articles'], exist_ok=True)
+    for faq in FAQ.list_all():
+        filename = f'{faq.id}.rst'
+        destfile = os.path.join(DEST_DIRS['faq_articles'], filename)
+        if build_all or destfile in targets:
+            write_rst(templates['faq_article'], faq.template_object(LANG), destfile)
+
+    os.makedirs(DEST_DIRS['faq_tags'], exist_ok=True)
+    for tag in FAQ_Tag.list_all():
+        filename = f'{tag.id}.rst'
+        destfile = os.path.join(DEST_DIRS['faq_tags'], filename)
+        if tag.article_count() > 0 and build_all or destfile in targets:
+            write_rst(templates['faq_tagpage'], tag.template_object(LANG), destfile)
+
+    sorted_tags = sorted(FAQ_Tag.list_all(), key=lambda x: x.names[LANG])
+    tags = [tag.template_object(LANG) for tag in sorted_tags if tag.article_count() > 0]
+    tagpages = [tagpage.template_object(LANG) for tagpage in sorted_tags if tagpage.article_count() > 0]
+    sorted_articles_by_date = FAQ.list_all(sort_by='date')
+    sorted_articles_by_sortkey = FAQ.list_all(sort_by='sortKey')
+    if build_all or STATIC_FILES['faq_index'] in targets:
+        articles = [article.template_object(LANG) for article in sorted_articles_by_date]
+        write_rst(templates['faq_index'], {'articles': articles, 'tags': tags}, STATIC_FILES['faq_index'])
+        
+    if build_all or STATIC_FILES['faq_tag_index'] in targets:
+        write_rst(templates['faq_tag_index'], {'tags': tagpages}, STATIC_FILES['faq_tag_index'])
+
+    if build_all or STATIC_FILES['FAQ_ARTICLE_INDEX_PATH'] in targets:
+        articles = [article.template_object(LANG) for article in sorted_articles_by_sortkey]
+        write_rst(templates['faq_article_index'], {'articles': articles}, STATIC_FILES['faq_article_index'])
+
+    os.makedirs(DEST_DIRS['info2gl'], exist_ok=True)
+    for info in InfoRef.get_all_internals():
+        if len(info.guidelines) > 0:
+            filename = f'{info.ref}.rst'
+            destfile = os.path.join(os.getcwd(), DEST_DIRS['info2gl'], filename)
+            if build_all or destfile in targets:
+                write_rst(templates['info_to_gl'], {'guidelines': info.get_guidelines(LANG)}, destfile)
+
+    os.makedirs(DEST_DIRS['info2faq'], exist_ok=True)
+    for info in InfoRef.get_all_internals():
+        if len(info.faqs) > 0:
+            filename = f'{info.ref}.rst'
+            destfile = os.path.join(os.getcwd(), DEST_DIRS['info2faq'], filename)
+            makefile_vars_list['info_to_faq_target'].append(destfile)
+            if build_all or destfile in targets:
+                write_rst(templates['info_to_faq'], {'faqs': info.get_faqs()}, destfile)
+
+    os.makedirs(DEST_DIRS['misc'], exist_ok=True)
+    if build_all or STATIC_FILES['wcag21mapping'] in targets:
+        sc_mapping = [sc.template_object(LANG) for sc in WCAG_SC.get_all().values() if len(sc.guidelines) > 0]
+        write_rst(templates['wcag21mapping'], {'mapping': sc_mapping}, STATIC_FILES['wcag21mapping'])
+
+    if build_all or STATIC_FILES['priority_diff'] in targets:
+        diffs = [sc.template_object(LANG) for sc in WCAG_SC.get_all().values() if sc.level != sc.localPriority]
+        write_rst(templates['priority_diff'], {'diffs': diffs}, STATIC_FILES['priority_diff'])
 
     if build_all or STATIC_FILES['miscdefs'] in targets:
         try:
@@ -486,124 +213,53 @@ def main():
             })
         write_rst(templates['miscdefs'], {'links': external_info_links}, STATIC_FILES['miscdefs'])
 
-    if build_all or len(build_examples):
-        for tool in check_examples:
-            if check_examples[tool] == '' or not tool in build_examples:
-                continue
-            filename = f'examples-{tool}.rst'
-            destfile = os.path.join(DEST_DIRS['checks'], filename)
-            write_rst(templates['tool_example'], {'examples': check_examples[tool]}, destfile)
-
     if build_all or STATIC_FILES['makefile'] in targets:
-        gl_yaml = []
-        for obj in guidelines:
-            gl_yaml.append(obj['src_path'])
-        check_yaml = []
-        for obj in checks:
-            check_yaml.append(obj['src_path'])
-        faq_yaml = []
-        for obj in faqs:
-            faq_yaml.append(obj['src_path'])
-        all_yaml = gl_yaml + check_yaml + faq_yaml
+        build_depends = []
+        for cat in Category.list_all():
+            filename = f'{cat.id}.rst'
+            destfile = os.path.join(DEST_DIRS['guidelines'], filename)
+            makefile_vars_list['guideline_category_target'].append(destfile)
+            build_depends.append({'target': destfile, 'depends': ' '.join(cat.get_dependency())})
 
-        other_deps = []
-        for cat in category_pages:
-            target = os.path.join(DEST_DIRS['guidelines'], f'{cat}.rst')
-            deps = " ".join(uniq(category_pages[cat]['dependency']))
-            other_deps.append({
-                'dep': f'{target}: {deps}',
-                'target': target
-            })
-        check_example_target = []
-        for tool in check_examples:
-            if check_examples[tool] == '' or not tool in build_examples:
+        for tool in CheckTool.list_all():
+            filename = f'examples-{tool.id}.rst'
+            destfile = os.path.join(DEST_DIRS['checks'], filename)
+            makefile_vars_list['check_example_target'].append(destfile)
+            build_depends.append({'target': destfile, 'depends': ' '.join(tool.get_dependency())})
+
+        for faq in FAQ.list_all():
+            filename = f'{faq.id}.rst'
+            destfile = os.path.join(DEST_DIRS['faq_articles'], filename)
+            makefile_vars_list['faq_article_target'].append(destfile)
+            build_depends.append({'target': destfile, 'depends': ' '.join(faq.get_dependency())})
+
+        for tag in FAQ_Tag.list_all():
+            if tag.article_count() == 0:
                 continue
-            target = os.path.join(DEST_DIRS['checks'], f'examples-{tool}.rst')
-            check_example_target.append(target)
-            _deps = []
-            for ex in check_examples[tool]:
-                _deps.append([x for x in checks if x["id"] == ex['id']][0]['src_path'])
-            deps = " ".join(_deps)
-            other_deps.append({
-                'dep': f'{target}: {deps}',
-                'target': target
-            })
-        faq_article_target = []
-        for faq in faqs:
-            target = os.path.join(DEST_DIRS['faq_articles'], f'{faq["id"]}.rst')
-            faq_article_target.append(target)
-            _deps = []
-            _deps.append(faq["src_path"])
-            if 'guidelines' in faq:
-                for gl in faq['guidelines']:
-                    _deps.append([x for x in guidelines if x["id"] == gl][0]['src_path'])
-            if 'checks' in faq:
-                for c in faq['checks']:
-                    _deps.append([x for x in checks if x["id"] == c][0]['src_path'])
-            deps = " ".join(_deps)
-            other_deps.append({
-                'dep': f'{target}: {deps}',
-                'target': target
-            })
-        faq_tagpage_target = []
-        for tag in faq_tagpages:
-            target = os.path.join(DEST_DIRS['faq_tags'], f'{tag}.rst')
-            faq_tagpage_target.append(target)
-            _deps = []
-            for faq in faq_tagpages[tag]['articles']:
-                _deps.append([x for x in faqs if x["id"] == faq][0]['src_path'])
-            deps = " ".join(_deps)
-            other_deps.append({
-                'dep': f'{target}: {deps}',
-                'target': target
-            })
+            filename = f'{tag.id}.rst'
+            destfile = os.path.join(DEST_DIRS['faq_tags'], filename)
+            makefile_vars_list['faq_tagpage_target'].append(destfile)
+            build_depends.append({'target': destfile, 'depends': [' '.join(faq.get_dependency()) for faq in tag.faqs]})
 
-        info_to_faq_target = []
-        for info in info_to_faq:
-            target = os.path.join(DEST_DIRS['info2faq'], f'{info}.rst')
-            deps = " ".join([faq['src_path'] for faq in faqs for id in [x['id'] for x in info_to_faq[info]] if faq.get('id') == id])
-            info_to_faq_target.append(target)
-            other_deps.append({
-                'dep': f'{target}: {deps}',
-                'target': target
-            })
-            
-        info_to_gl_target = []
-        for info in info_to_gl:
-            target = os.path.join(DEST_DIRS['info2gl'], f'{info}.rst')
-            deps = " ".join([guideline['src_path'] for guideline in guidelines for id in [x['id'] for x in info_to_gl[info]] if guideline.get('id') == id])
-            info_to_gl_target.append(target)
-            other_deps.append({
-                'dep': f'{target}: {deps}',
-                'target': target
-            })
-        faq_index_pages = []
-        faq_index_pages.append(STATIC_FILES['faq_index'])
-        faq_index_pages.append(STATIC_FILES['faq_article_index'])
-        faq_index_pages.append(STATIC_FILES['faq_tag_index'])
+        for info in InfoRef.get_all_internals():
+            if len(info.guidelines) > 0:
+                filename = f'{info.ref}.rst'
+                destfile = os.path.join(os.getcwd(), DEST_DIRS['info2gl'], filename)
+                makefile_vars_list['info_to_gl_target'].append(destfile)
+                build_depends.append({'target': destfile, 'depends': ' '.join([guideline.src_path for guideline in info.guidelines])})
 
-        makefile_data = {
-            'guideline_category_target': " ".join(guideline_category_target),
-            'check_example_target': " ".join(check_example_target),
-            'faq_tagpage_target': " ".join(faq_tagpage_target),
-            'faq_article_target': " ".join(faq_article_target),
-            'faq_index_target': " ".join(faq_index_pages),
-            'wcag_mapping_target': STATIC_FILES['wcag21mapping'],
-            'priority_diff_target': STATIC_FILES['priority_diff'],
-            'all_checks_target': STATIC_FILES['all_checks'],
-            'wcag_sc': MISC_INFO_SRCFILES['wcag_sc'],
-            'gl_yaml': " ".join(gl_yaml),
-            'check_yaml': " ".join(check_yaml),
-            'faq_yaml': " ".join(faq_yaml),
-            'all_yaml': " ".join(all_yaml),
-            'info_to_gl_target': " ".join(info_to_gl_target),
-            'info_to_faq_target': " ".join(info_to_faq_target),
-            'other_deps': other_deps,
-            'miscdefs_target': STATIC_FILES['miscdefs'],
-            'info_src': MISC_INFO_SRCFILES['info']
-        }
+            if info.internal and len(info.faqs) > 0:
+                filename = f'{info.ref}.rst'
+                destfile = os.path.join(os.getcwd(), DEST_DIRS['info2faq'], filename)
+                makefile_vars_list['info_to_faq_target'].append(destfile)
+                build_depends.append({'target': destfile, 'depends': ' '.join([faq.src_path for faq in info.faqs])})
+
+        for key, value in makefile_vars_list.items():
+            makefile_vars[key] = ' '.join(value)
+            makefile_vars['depends'] = build_depends
         destfile = STATIC_FILES['makefile']
-        write_rst(templates['makefile'], makefile_data, destfile)
+        write_rst(templates['makefile'], makefile_vars, destfile)
+
 
 def ls_dir(dir):
     files = []
@@ -690,10 +346,6 @@ def process_yaml_file(file_path, schema_dir, schema_file, no_check, resolver):
 
     data['src_path'] = os.path.relpath(file_path, start=os.getcwd())
     return data
-
-def uniq(seq):
-    seen = []
-    return [x for x in seq if x not in seen and not seen.append(x)]
 
 def make_heading(title, level, className=""):
     

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -76,11 +76,9 @@ PLATFORM_NAMES = {
 
 def main():
     args = parse_args()
-    if not args.files:
-        build_all = True
-    else:
-        build_all = False
-        targets = args.files
+    settings = process_arguments(args)
+    build_all = settings.get('build_all')
+    targets = settings.get('targets')
 
     template_env = Environment(
         loader=FileSystemLoader(os.path.join(os.path.dirname(__file__), TEMPLATE_DIR))
@@ -807,6 +805,27 @@ def parse_args():
     parser.add_argument('--no-check', action='store_true', help='Do not run various checks of YAML files')
     parser.add_argument('files', nargs='*', help='Filenames')
     return parser.parse_args()
+
+def process_arguments(args):
+    """
+    Process the command-line arguments to determine the build mode, target files, and other options.
+
+    Args:
+        args: The parsed command-line arguments.
+
+    Returns:
+        A dictionary containing settings derived from the command-line arguments.
+    """
+    settings = {
+        'build_all': not args.files,
+        'targets': args.files if args.files else []
+    }
+
+    # 例：新しいオプション 'verbose' の処理
+    # if hasattr(args, 'verbose'):
+    #     settings['verbose'] = args.verbose
+
+    return settings
 
 if __name__ == "__main__":
     main()

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -369,29 +369,23 @@ def main():
     os.makedirs(os.path.join(os.getcwd(), GUIDELINES_DESTDIR), exist_ok=True)
     for cat in category_pages:
         filename = f'{cat}.rst'
-        if build_all or os.path.join(GUIDELINES_DESTDIR, filename) in targets:
-            output = templates['category_page'].render(guidelines = category_pages[cat]['guidelines'])
-            destfile = os.path.join(os.getcwd(), GUIDELINES_DESTDIR, filename)
-            with open(destfile, mode="w", encoding="utf-8", newline="\n") as f:
-                f.write(output)
+        destfile = os.path.join(os.getcwd(), GUIDELINES_DESTDIR, filename)
+        if build_all or destfile in targets:
+            write_rst(templates['category_page'], {'guidelines': category_pages[cat]['guidelines']}, destfile)
 
     os.makedirs(os.path.join(os.getcwd(), INFO_TO_GL_DESTDIR), exist_ok=True)
     for info in info_to_gl:
         filename = f'{info}.rst'
-        if build_all or os.path.join(INFO_TO_GL_DESTDIR, filename) in targets:
-            output = templates['info_to_gl'].render(guidelines = sorted(info_to_gl[info], key=lambda x: x['sortKey']))
-            destfile = os.path.join(os.getcwd(), INFO_TO_GL_DESTDIR, filename)
-            with open(destfile, mode="w", encoding="utf-8", newline="\n") as f:
-                f.write(output)
+        destfile = os.path.join(os.getcwd(), INFO_TO_GL_DESTDIR, filename)
+        if build_all or destfile in targets:
+            write_rst(templates['info_to_gl'], {'guidelines': sorted(info_to_gl[info], key=lambda x: x['sortKey'])}, destfile)
 
     os.makedirs(os.path.join(os.getcwd(), INFO_TO_FAQ_DESTDIR), exist_ok=True)
     for info in info_to_faq:
         filename = f'{info}.rst'
-        if build_all or os.path.join(INFO_TO_FAQ_DESTDIR, filename) in targets:
-            output = templates['info_to_faq'].render(faqs = sorted(info_to_faq[info], key=lambda x: x['sortKey']))
-            destfile = os.path.join(os.getcwd(), INFO_TO_FAQ_DESTDIR, filename)
-            with open(destfile, mode="w", encoding="utf-8", newline="\n") as f:
-                f.write(output)
+        destfile = os.path.join(os.getcwd(), INFO_TO_FAQ_DESTDIR, filename)
+        if build_all or destfile in targets:
+            write_rst(templates['info_to_faq'], {'faqs': sorted(info_to_faq[info], key=lambda x: x['sortKey'])}, destfile)
 
     os.makedirs(os.path.join(os.getcwd(), FAQ_ARTICLES_DESTDIR), exist_ok=True)
     faq_articles = []
@@ -407,7 +401,8 @@ def main():
             'updated_day': faq_updated.day
         })
         article_filename = f'{faq["id"]}.rst'
-        if build_all or os.path.join(FAQ_ARTICLES_DESTDIR, article_filename) in targets:
+        destfile = os.path.join(os.getcwd(), FAQ_ARTICLES_DESTDIR, article_filename)
+        if build_all or destfile in targets:
             faq_obj = {
                 'id': faq['id'],
                 'title': faq['title'][LANG],
@@ -436,10 +431,7 @@ def main():
                         'category': gl_categories[gl]
                     })
             faq['destpath'] = os.path.join(FAQ_ARTICLES_DESTDIR, article_filename)
-            output = templates['faq_article'].render(faq_obj)
-            destfile = os.path.join(os.getcwd(), FAQ_ARTICLES_DESTDIR, article_filename)
-            with open(destfile, mode="w", encoding="utf-8", newline="\n") as f:
-                f.write(output)
+            write_rst(templates['faq_article'], faq_obj, destfile)
 
         for tag in faq['tags']:
             try:
@@ -462,32 +454,22 @@ def main():
 
     os.makedirs(os.path.join(os.getcwd(), FAQ_TAGPAGES_DESTDIR), exist_ok=True)
     for page in faq_tagpage_list:
-        if build_all or os.path.join(FAQ_TAGPAGES_DESTDIR, f'{page["tag"]}.rst') in targets:
-            output = templates['faq_tagpage'].render(page)
-            destfile = os.path.join(FAQ_TAGPAGES_DESTDIR, f'{page["tag"]}.rst')
-            with open(destfile, mode="w", encoding="utf-8", newline="\n") as f:
-                f.write(output)
+        filename = f'{page["tag"]}.rst'
+        destfile = os.path.join(FAQ_TAGPAGES_DESTDIR, filename)
+        if build_all or destfile in targets:
+            write_rst(templates['faq_tagpage'], page, destfile)
 
     if build_all or FAQ_INDEX_PATH in targets:
-        output = templates['faq_index'].render(files = sorted(faq_articles, key=lambda x: x['updated'], reverse=True), tags = faq_tagpage_list)
-        destfile = FAQ_INDEX_PATH
-        with open(destfile, mode="w", encoding="utf-8", newline="\n") as f:
-            f.write(output)
+        write_rst(templates['faq_index'], {'files': sorted(faq_articles, key=lambda x: x['updated'], reverse=True), 'tags': faq_tagpage_list}, FAQ_INDEX_PATH)
 
     if build_all or FAQ_TAG_INDEX_PATH in targets:
-        output = templates['faq_tag_index'].render(tags = faq_tagpage_list)
-        destfile = FAQ_TAG_INDEX_PATH
-        with open(destfile, mode="w", encoding="utf-8", newline="\n") as f:
-            f.write(output)
+        write_rst(templates['faq_tag_index'], {'tags': faq_tagpage_list}, FAQ_TAG_INDEX_PATH)
 
     if build_all or FAQ_ARTICLE_INDEX_PATH in targets:
-        output = templates['faq_article_index'].render(files = sorted(faq_articles, key=lambda x: x['sortKey']))
-        destfile = FAQ_ARTICLE_INDEX_PATH
-        with open(destfile, mode="w", encoding="utf-8", newline="\n") as f:
-            f.write(output)
+        write_rst(templates['faq_article_index'], {'files': sorted(faq_articles, key=lambda x: x['sortKey'])}, FAQ_ARTICLE_INDEX_PATH)
 
     os.makedirs(os.path.join(os.getcwd(), MISC_DESTDIR), exist_ok=True)
-    if build_all or os.path.join(MISC_DESTDIR, WCAG_MAPPING_FILENAME) in targets:
+    if build_all or WCAG_MAPPING_PATH in targets:
         sc_mapping = []
         for sc in wcag_sc:
             if len(wcag_sc[sc]['gls']) == 0:
@@ -504,12 +486,9 @@ def main():
                 'gls': gls_str
             }
             sc_mapping.append(mapping)
+        write_rst(templates['wcag21mapping'], {'mapping': sc_mapping}, WCAG_MAPPING_PATH)
 
-        sc_mapping_text = templates['wcag21mapping'].render({'mapping': sc_mapping})
-        with open(WCAG_MAPPING_PATH, mode="w", encoding="utf-8", newline="\n") as f:
-            f.write(sc_mapping_text)
-
-    if build_all or os.path.join(MISC_DESTDIR, PRIORITY_DIFF_FILENAME) in targets:
+    if build_all or PRIORITY_DIFF_PATH in targets:
         diffs = []
         for sc in wcag_sc:
             if wcag_sc[sc]['level'] == wcag_sc[sc]['localPriority']:
@@ -522,18 +501,13 @@ def main():
                 'LocalLevel': wcag_sc[sc]['localPriority']
             }
             diffs.append(diff)
-
-        diffs_text = templates['priority_diff'].render({'diffs': diffs})
-        with open(PRIORITY_DIFF_PATH, mode="w", encoding="utf-8", newline="\n") as f:
-            f.write(diffs_text)
+        write_rst(templates['priority_diff'], {'diffs': diffs}, PRIORITY_DIFF_PATH)
 
     os.makedirs(os.path.join(os.getcwd(), CHECKS_DESTDIR), exist_ok=True)
-    if build_all or os.path.join(CHECKS_DESTDIR, ALL_CHECKS_FILENAME) in targets:
-        allcheck_text = templates['allchecks_text'].render({'allchecks': allchecks})
-        with open(ALL_CHECKS_PATH, mode="w", encoding="utf-8", newline="\n") as f:
-            f.write(allcheck_text)
+    if build_all or ALL_CHECKS_PATH in targets:
+        write_rst(templates['allchecks_text'], {'allchecks': allchecks}, ALL_CHECKS_PATH)
 
-    if build_all or os.path.join(MISC_DESTDIR, MISCDEFS_FILENAME) in targets:
+    if build_all or MISCDEFS_PATH in targets:
         try:
             with open(INFO_SRC, encoding='utf-8') as f:
                 info_links = json.load(f)
@@ -549,9 +523,7 @@ def main():
                 'text': info_links[link]['text'][LANG],
                 'url': info_links[link]['url'][LANG]
             })
-        miscdefs_text = templates['miscdefs'].render({'links': external_info_links})
-        with open(MISCDEFS_PATH, mode="w", encoding="utf-8", newline="\n") as f:
-            f.write(miscdefs_text)
+        write_rst(templates['miscdefs'], {'links': external_info_links}, MISCDEFS_PATH)
 
     if build_all or len(build_examples):
         for tool in check_examples:
@@ -559,8 +531,7 @@ def main():
                 continue
             filename = f'examples-{tool}.rst'
             destfile = os.path.join(os.getcwd(), CHECKS_DESTDIR, filename)
-            with open(destfile, mode="w", encoding="utf-8", newline="\n") as f:
-                f.write(templates['tool_example'].render({'examples': check_examples[tool]}))
+            write_rst(templates['tool_example'], {'examples': check_examples[tool]}, destfile)
 
     if build_all or MAKEFILE_FILENAME in targets:
         gl_yaml = []
@@ -670,11 +641,8 @@ def main():
             'miscdefs_target': os.path.join(MISC_DESTDIR, MISCDEFS_FILENAME),
             'info_src': INFO_SRC
         }
-        makefile_str = templates['makefile'].render(makefile_data)
-
         destfile = os.path.join(os.getcwd(),  MAKEFILE_FILENAME)
-        with open(destfile, mode="w", encoding="utf-8", newline="\n") as f:
-            f.write(makefile_str)
+        write_rst(templates['makefile'], makefile_data, destfile)
 
 def ls_dir(dir):
     files = []
@@ -855,6 +823,22 @@ def load_templates(template_env):
     
     templates = {name: template_env.get_template(filename) for name, filename in template_filenames.items()}
     return templates
+
+def write_rst(template, data, output_path):
+    """
+    Render a Jinja2 template with provided data and write the output to an RST file.
+
+    Args:
+        template: Jinja2 template object.
+        data: Data to be used in the template.
+        output_path: Path to the output RST file.
+
+    Returns:
+        None
+    """
+    rendered_content = template.render(data)
+    with open(output_path, mode='w', encoding='utf-8', newline='\n') as file:
+        file.write(rendered_content)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- コマンド・ライン・オプションの処理の改善
- テンプレートの読み込み処理を関数化
- YAMLの読み込み、処理、バリテーションの関数化
- RST書き出し部分を関数化
- ファイル読み込み箇所の処理を改善
- 出力ファイルの言語設定を定数ではなくコマンドライン・オプションで指定できる変数に変更。
- 各種パスの定義をconfig.pyに分離
- WCAG達成基準の情報の処理を修正
- 全面的なコードの見直し
- Add sort keys.
- "id"を追加
- pycacheを無視
