### PR TITLE
yaml2rst.py: ガイドライン、チェック、FAQなどのオブジェクト間の関係を一元的に管理

### DIFF
--- a/tools/yaml2rst/a11y_guidelines.py
+++ b/tools/yaml2rst/a11y_guidelines.py
@@ -619,7 +619,7 @@ class Technique:
             'technique': self.technique[lang]
         }
         if self.note:
-            template_object['note'] = self.note[lang]        
+            template_object['note'] = self.note[lang]
         if self.YouTube:
             template_object['YouTube'] = self.YouTube.template_object()
         return template_object
@@ -634,7 +634,7 @@ class YouTube:
             'id': self.id,
             'title': self.title
         }
-    
+
 class Implementation:
     def __init__(self, title, methods):
         self.title = title
@@ -671,7 +671,7 @@ class Method:
             'platform': IMPLEMENTATION_TARGETS[self.platform][lang],
             'method': self.method
         }
-    
+
 class CheckTool:
     all_tools = {}
 
@@ -702,7 +702,7 @@ class CheckTool:
         }
         example_objects = []
         for example in self.examples:
-            example_objects.append(example.template_object(lang)) 
+            example_objects.append(example.template_object(lang))
         template_object['examples'] = sorted(example_objects, key=lambda item: item['check_id'])
         return template_object
 

--- a/tools/yaml2rst/a11y_guidelines.py
+++ b/tools/yaml2rst/a11y_guidelines.py
@@ -447,13 +447,6 @@ class FAQ_Tag:
             return self.names[lang]
         return self.names['en']
 
-    def get_faqs_ids(self):
-        return sorted([str(faq.id) for faq in self.faqs])
-
-    def get_dependency(self):
-        dependency = [faq.src_path for faq in self.faqs]
-        return uniq(dependency)
-
     def template_object(self, lang):
         rel = RelationshipManager()
         faqs = rel.get_tag_to_faqs(self)

--- a/tools/yaml2rst/a11y_guidelines.py
+++ b/tools/yaml2rst/a11y_guidelines.py
@@ -45,12 +45,12 @@ class RelationshipManager:
     def get_guidelines_to_category(self):
         mapping = {}
         for category, guidelines in self.category_to_guidelines.items():
-            sorted_guidelines = sorted(guidelines, key=lambda item: item.sortKey)
+            sorted_guidelines = sorted(guidelines, key=lambda item: item.sort_key)
             mapping[category] = sorted_guidelines
         return mapping
 
     def get_category_to_guidelines(self, category):
-        return sorted(self.category_to_guidelines[category.id], key=lambda item: item.sortKey)
+        return sorted(self.category_to_guidelines[category.id], key=lambda item: item.sort_key)
 
     def associate_guideline_with_check(self, guideline, check):
         if guideline.id not in self.guideline_to_checks:
@@ -63,7 +63,7 @@ class RelationshipManager:
             self.check_to_guidelines[check.id].append(guideline)
 
     def get_check_to_guidelines(self, check):
-        return sorted(self.check_to_guidelines[check.id], key=lambda item: item.sortKey)
+        return sorted(self.check_to_guidelines[check.id], key=lambda item: item.sort_key)
 
     def get_guideline_to_checks(self, guideline):
         return sorted(self.guideline_to_checks[guideline.id], key=lambda item: item.id)
@@ -79,12 +79,12 @@ class RelationshipManager:
             self.sc_to_guidelines[sc.id].append(guideline)
 
     def get_guideline_to_scs(self, guideline):
-        return sorted(self.guideline_to_scs[guideline.id], key=lambda item: item.sortKey)
+        return sorted(self.guideline_to_scs[guideline.id], key=lambda item: item.sort_key)
 
     def get_sc_to_guidelines(self, sc):
         if sc.id not in self.sc_to_guidelines:
             return []
-        return sorted(self.sc_to_guidelines[sc.id], key=lambda item: item.sortKey)
+        return sorted(self.sc_to_guidelines[sc.id], key=lambda item: item.sort_key)
 
     def associate_guideline_with_info(self, guideline, info):
         if guideline.id not in self.guideline_to_info:
@@ -201,7 +201,7 @@ class Guideline:
 
     def __init__(self, gl):
         self.id = gl['id']
-        self.sortKey = gl['sortKey']
+        self.sort_key = gl['sortKey']
         self.title = gl['title']
         self.platform = gl['platform']
         self.guideline = gl['guideline']
@@ -213,7 +213,7 @@ class Guideline:
         for check_id in gl['checks']:
             rel.associate_guideline_with_check(self, Check.get_by_id(check_id))
         for sc in gl['sc']:
-            rel.associate_guideline_with_sc(self, WCAG_SC.get_by_id(sc))
+            rel.associate_guideline_with_sc(self, WcagSc.get_by_id(sc))
 
         if 'info' in gl:
             for info in gl['info']:
@@ -241,7 +241,7 @@ class Guideline:
         }
         faqs = rel.get_guideline_to_faqs(self)
         if len(faqs):
-            template_object['faqs'] = [faq.id for faq in sorted(faqs, key=lambda item: item.sortKey)]
+            template_object['faqs'] = [faq.id for faq in sorted(faqs, key=lambda item: item.sort_key)]
         info = rel.get_guideline_to_info(self)
         if len(info):
             template_object['info'] = [inforef.refstring() for inforef in info]
@@ -303,7 +303,7 @@ class Check:
             template_object['info_refs'] = [inforef.refstring() for inforef in info]
         faqs = rel.get_check_to_faqs(self)
         if len(faqs) > 0:
-            template_object['faqs'] = [faq.id for faq in sorted(faqs, key=lambda item: item.sortKey)]
+            template_object['faqs'] = [faq.id for faq in sorted(faqs, key=lambda item: item.sort_key)]
         for gl in rel.get_check_to_guidelines(self):
             template_object['guidelines'].append(gl.get_category_and_id(lang))
         return template_object
@@ -317,12 +317,12 @@ class Check:
         sorted_checks = sorted(cls.all_checks, key=lambda x: cls.all_checks[x].id)
         return [cls.all_checks[check_id].template_object(lang) for check_id in sorted_checks]
 
-class FAQ:
+class Faq:
     all_faqs = {}
 
     def __init__(self, faq):
         self.id = faq['id']
-        self.sortKey = faq['sortKey']
+        self.sort_key = faq['sortKey']
         self.updated = datetime.datetime.fromisoformat(faq['updated'])
         self.title = faq['title']
         self.problem = faq['problem']
@@ -336,7 +336,7 @@ class FAQ:
                 rel.associate_faq_with_guideline(self, Guideline.get_by_id(guideline_id))
 
         for tag in faq['tags']:
-            rel.associate_faq_with_tag(self, FAQ_Tag.get_by_id(tag))
+            rel.associate_faq_with_tag(self, FaqTag.get_by_id(tag))
 
         if 'checks' in faq:
             for check_id in faq['checks']:
@@ -346,7 +346,7 @@ class FAQ:
             for info in faq['info']:
                 rel.associate_faq_with_info(self, InfoRef(info))
 
-        FAQ.all_faqs[self.id] = self
+        Faq.all_faqs[self.id] = self
 
     def get_dependency(self):
         rel = RelationshipManager()
@@ -376,7 +376,7 @@ class FAQ:
         }
         guidelines = rel.get_faq_to_guidelines(self)
         if len(guidelines):
-            sorted_guidelines = sorted(guidelines, key=lambda item: item.sortKey)
+            sorted_guidelines = sorted(guidelines, key=lambda item: item.sort_key)
             template_object['guidelines'] = [guideline.get_category_and_id(lang) for guideline in sorted_guidelines]
         checks = rel.get_faq_to_checks(self)
         if len(checks):
@@ -392,7 +392,7 @@ class FAQ:
         if 'sort_by' in kwargs:
             if kwargs['sort_by'] == 'date':
                 return sorted(cls.all_faqs.values(), key=lambda faq: faq.updated, reverse=True)
-        return sorted(cls.all_faqs.values(), key=lambda faq: faq.sortKey)
+        return sorted(cls.all_faqs.values(), key=lambda faq: faq.sort_key)
 
 class Category:
     all_categories = {}
@@ -431,13 +431,13 @@ class Category:
     def list_all(cls):
         return cls.all_categories.values()
 
-class FAQ_Tag:
+class FaqTag:
     all_tags = {}
 
     def __init__(self, tag_id, names):
         self.id = tag_id
         self.names = names
-        FAQ_Tag.all_tags[tag_id] = self
+        FaqTag.all_tags[tag_id] = self
 
     def article_count(self):
         rel = RelationshipManager()
@@ -453,7 +453,7 @@ class FAQ_Tag:
         faqs = rel.get_tag_to_faqs(self)
         if len(faqs) == 0:
             return None
-        sorted_faqs = sorted(faqs, key=lambda item: item.sortKey)
+        sorted_faqs = sorted(faqs, key=lambda item: item.sort_key)
         return {
             'tag': self.id,
             'label': self.names[lang],
@@ -474,14 +474,14 @@ class FAQ_Tag:
                 return sorted(cls.all_tags.values(), key=lambda tag: tag.names['en'])
         return cls.all_tags.values()
 
-class WCAG_SC:
+class WcagSc:
     all_scs = {}
 
     def __init__(self, sc):
         self.id = sc['id']
-        self.sortKey = sc['sortKey']
+        self.sort_key = sc['sortKey']
         self.level = sc['level']
-        self.localPriority = sc['localPriority']
+        self.local_priority = sc['localPriority']
         self.title = {
             'ja': sc['ja']['title'],
             'en': sc['en']['title']
@@ -490,14 +490,14 @@ class WCAG_SC:
             'ja': sc['ja']['url'],
             'en': sc['en']['url']
         }
-        WCAG_SC.all_scs[self.id] = self
+        WcagSc.all_scs[self.id] = self
 
     def template_object(self, lang):
         rel = RelationshipManager()
         template_object =  {
             'sc': self.id,
             'level': self.level,
-            'LocalLevel': self.localPriority,
+            'LocalLevel': self.local_priority,
             'sc_en_title': self.title['en'],
             'sc_ja_title': self.title['ja'],
             'sc_en_url': self.url['en'],
@@ -514,7 +514,7 @@ class WCAG_SC:
 
     @classmethod
     def get_all(cls):
-        sorted_keys = sorted(cls.all_scs.keys(), key=lambda sc: cls.all_scs[sc].sortKey)
+        sorted_keys = sorted(cls.all_scs.keys(), key=lambda sc: cls.all_scs[sc].sort_key)
         return {key: cls.get_by_id(key) for key in sorted_keys}
 
 class InfoRef:
@@ -595,9 +595,9 @@ class Technique:
         else:
             self.note = None
         if 'YouTube' in kwargs:
-            self.YouTube = YouTube(**kwargs['YouTube'])
+            self.youtube = YouTube(**kwargs['YouTube'])
         else:
-            self.YouTube = None
+            self.youtube = None
 
     def template_object(self, lang):
         if not self.tool_display_name:
@@ -608,8 +608,8 @@ class Technique:
         }
         if self.note:
             template_object['note'] = self.note[lang]
-        if self.YouTube:
-            template_object['YouTube'] = self.YouTube.template_object()
+        if self.youtube:
+            template_object['YouTube'] = self.youtube.template_object()
         return template_object
 
 class YouTube:

--- a/tools/yaml2rst/a11y_guidelines.py
+++ b/tools/yaml2rst/a11y_guidelines.py
@@ -247,8 +247,8 @@ class Guideline:
         return template_object
 
     @classmethod
-    def get_by_id(cls, id):
-        return cls.all_guidelines.get(id)
+    def get_by_id(cls, guideline_id):
+        return cls.all_guidelines.get(guideline_id)
 
 class Check:
     all_checks = {}
@@ -308,8 +308,8 @@ class Check:
         return template_object
 
     @classmethod
-    def get_by_id(cls, id):
-        return cls.all_checks.get(id)
+    def get_by_id(cls, check_id):
+        return cls.all_checks.get(check_id)
 
     @classmethod
     def template_object_all(cls, lang):
@@ -398,11 +398,11 @@ class FAQ:
 class Category:
     all_categories = {}
 
-    def __init__(self, id, names):
-        self.id = id
+    def __init__(self, category_id, names):
+        self.id = category_id
         self.names = names
         self.guidelines = []
-        Category.all_categories[id] = self
+        Category.all_categories[category_id] = self
 
     def add_guideline(self, guideline):
         if guideline in self.guidelines:
@@ -426,8 +426,8 @@ class Category:
         return uniq(dependency)
 
     @classmethod
-    def get_by_id(cls, id):
-        return cls.all_categories.get(id)
+    def get_by_id(cls, category_id):
+        return cls.all_categories.get(category_id)
 
     @classmethod
     def list_all(cls):
@@ -436,10 +436,10 @@ class Category:
 class FAQ_Tag:
     all_tags = {}
 
-    def __init__(self, id, names):
-        self.id = id
+    def __init__(self, tag_id, names):
+        self.id = tag_id
         self.names = names
-        FAQ_Tag.all_tags[id] = self
+        FAQ_Tag.all_tags[tag_id] = self
 
     def article_count(self):
         rel = RelationshipManager()
@@ -472,8 +472,8 @@ class FAQ_Tag:
         }
 
     @classmethod
-    def get_by_id(cls, id):
-        return cls.all_tags.get(id)
+    def get_by_id(cls, tag_id):
+        return cls.all_tags.get(tag_id)
 
     @classmethod
     def list_all(cls, **kwargs):
@@ -519,8 +519,8 @@ class WCAG_SC:
         return template_object
 
     @classmethod
-    def get_by_id(cls, id):
-        return cls.all_scs.get(id)
+    def get_by_id(cls, sc_id):
+        return cls.all_scs.get(sc_id)
 
     @classmethod
     def get_all(cls):
@@ -531,12 +531,12 @@ class InfoRef:
     all_inforefs = {}
 
     def __new__(cls, ref, *args, **kwargs):
-        id = url_encode(ref)
-        if id in cls.all_inforefs:
-            return cls.all_inforefs[id]
+        ref_id = url_encode(ref)
+        if ref_id in cls.all_inforefs:
+            return cls.all_inforefs[ref_id]
         else:
             instance = super(InfoRef, cls).__new__(cls)
-            cls.all_inforefs[id] = instance
+            cls.all_inforefs[ref_id] = instance
             return instance
 
     def __init__(self, inforef):
@@ -625,9 +625,9 @@ class Technique:
         return template_object
 
 class YouTube:
-    def __init__(self, id, title):
-        self.id = id
-        self.title = title
+    def __init__(self, **kwargs):
+        self.id = kwargs['id']
+        self.title = kwargs['title']
 
     def template_object(self):
         return {
@@ -675,11 +675,11 @@ class Method:
 class CheckTool:
     all_tools = {}
 
-    def __init__(self, id, names):
-        self.id = id
+    def __init__(self, tool_id, names):
+        self.id = tool_id
         self.names = names
         self.examples = []
-        CheckTool.all_tools[id] = self
+        CheckTool.all_tools[tool_id] = self
 
     def add_example(self, example):
         self.examples.append(example)
@@ -715,8 +715,8 @@ class CheckTool:
         return cls.all_tools.keys()
 
     @classmethod
-    def get_by_id(cls, id):
-        return cls.all_tools.get(id)
+    def get_by_id(cls, tool_id):
+        return cls.all_tools.get(tool_id)
 
 # Utility functions
 def join_items(items, lang):

--- a/tools/yaml2rst/a11y_guidelines.py
+++ b/tools/yaml2rst/a11y_guidelines.py
@@ -195,6 +195,7 @@ class RelationshipManager:
         if info.id in self.info_to_faqs:
             return self.info_to_faqs.get(info.id)
         return []
+
 class Guideline:
     all_guidelines = {}
 
@@ -270,14 +271,14 @@ class Check:
         Check.all_checks[self.id] = self
 
     def procedure_platforms(self):
-        return sorted(list(set([procedure.platform for procedure in self.procedures])))
+        return sorted({procedure.platform for procedure in self.procedures})
 
     def template_object(self, lang, **kwargs):
         rel = RelationshipManager()
-        if 'platform' in kwargs:
-            gl_platform = kwargs['platform']
-        else:
-            gl_platform = []
+        # if 'platform' in kwargs:
+        gl_platform = kwargs.get('platform')
+        # else:
+            # gl_platform = []
         template_object = {
             'id': self.id,
             'check': self.check[lang],
@@ -287,7 +288,7 @@ class Check:
             'guidelines': []
         }
         if len(self.procedures) > 0:
-            if len(gl_platform) == 0:
+            if not gl_platform:
                 template_object['procedures'] = [procedure.template_object(lang) for procedure in self.procedures]
             else:
                 template_object['procedures'] = []
@@ -503,7 +504,7 @@ class WCAG_SC:
             'sc_ja_url': self.url['ja']
         }
         guidelines = rel.get_sc_to_guidelines(self)
-        if len(guidelines):
+        if len(guidelines) > 0:
             template_object['guidelines'] = [guideline.get_category_and_id(lang) for guideline in guidelines]
         return template_object
 
@@ -532,7 +533,7 @@ class InfoRef:
             return
         self.ref = inforef
         self.id = url_encode(self.ref)
-        self.internal = False if re.match(r'(https?://|\|.+\|)', self.ref) else True
+        self.internal = not bool(re.match(r'(https?://|\|.+\|)', self.ref))
         self.initialized = True
 
     def refstring(self):

--- a/tools/yaml2rst/a11y_guidelines.py
+++ b/tools/yaml2rst/a11y_guidelines.py
@@ -391,8 +391,6 @@ class FAQ:
         if 'sort_by' in kwargs:
             if kwargs['sort_by'] == 'date':
                 return sorted(cls.all_faqs.values(), key=lambda faq: faq.updated, reverse=True)
-            elif kwargs['sort_by'] == 'sortKey':
-                return sorted(cls.all_faqs.values(), key=lambda faq: faq.sortKey)
         return sorted(cls.all_faqs.values(), key=lambda faq: faq.sortKey)
 
 class Category:
@@ -413,8 +411,7 @@ class Category:
     def get_name(self, lang):
         if lang in self.names:
             return self.names[lang]
-        else:
-            return self.names['ja']
+        return self.names['ja']
 
     def get_dependency(self):
         rel = RelationshipManager()
@@ -448,8 +445,7 @@ class FAQ_Tag:
     def get_name(self, lang):
         if lang in self.names:
             return self.names[lang]
-        else:
-            return self.names['en']
+        return self.names['en']
 
     def get_faqs_ids(self):
         return sorted([str(faq.id) for faq in self.faqs])
@@ -480,7 +476,7 @@ class FAQ_Tag:
         if 'sort_by' in kwargs:
             if kwargs['sort_by'] == 'count':
                 return sorted(cls.all_tags.values(), key=lambda tag: tag.article_count(), reverse=True)
-            elif kwargs['sort_by'] == 'label':
+            if kwargs['sort_by'] == 'label':
                 return sorted(cls.all_tags.values(), key=lambda tag: tag.names['en'])
         return cls.all_tags.values()
 
@@ -534,10 +530,9 @@ class InfoRef:
         ref_id = url_encode(ref)
         if ref_id in cls.all_inforefs:
             return cls.all_inforefs[ref_id]
-        else:
-            instance = super(InfoRef, cls).__new__(cls)
-            cls.all_inforefs[ref_id] = instance
-            return instance
+        instance = super(InfoRef, cls).__new__(cls)
+        cls.all_inforefs[ref_id] = instance
+        return instance
 
     def __init__(self, inforef):
         if hasattr(self, 'initialized'):
@@ -550,8 +545,7 @@ class InfoRef:
     def refstring(self):
         if self.internal:
             return f':ref:`{self.ref}`'
-        else:
-            return self.ref
+        return self.ref
 
     @classmethod
     def get_all_internals(cls):
@@ -687,8 +681,7 @@ class CheckTool:
     def get_name(self, lang):
         if lang in self.names:
             return self.names[lang]
-        else:
-            return self.names['ja']
+        return self.names['ja']
 
     def get_dependency(self):
         dependency = []

--- a/tools/yaml2rst/config.py
+++ b/tools/yaml2rst/config.py
@@ -1,6 +1,6 @@
 import os
 
-# Default file locations and ohter configuration options for yaml2rst
+# Default file locations and other configuration options for yaml2rst
 #
 # List of languages that are available for file generation.
 AVAILABLE_LANGUAGES = ['ja']

--- a/tools/yaml2rst/config.py
+++ b/tools/yaml2rst/config.py
@@ -206,5 +206,3 @@ def get_static_dest_files(lang):
         'faq_tag_index': os.path.join(dest_dirnames['faq_tags'], FAQ_INDEX_FILENAME),
         'makefile': os.path.join(dest_dirnames['base'], MAKEFILE_FILENAME)
     }
-
-

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -7,7 +7,7 @@ import yaml
 from jsonschema import validate, ValidationError, RefResolver
 from jinja2 import Environment, FileSystemLoader
 from config import AVAILABLE_LANGUAGES, CHECK_TOOLS, SRCDIR, SCHEMA_FILENAMES, COMMON_SCHEMA_PATH, TEMPLATE_DIR, TEMPLATE_FILENAMES, MISC_INFO_SRCFILES, get_dest_dirnames, get_static_dest_files
-from a11y_guidelines import Category, WCAG_SC, InfoRef, Guideline, Check, FAQ, FAQ_Tag, CheckTool, RelationshipManager
+from a11y_guidelines import Category, WcagSc, InfoRef, Guideline, Check, Faq, FaqTag, CheckTool, RelationshipManager
 
 def main():
     args = parse_args()
@@ -89,7 +89,7 @@ def main():
     except Exception as e:
         handle_file_error(e, MISC_INFO_SRCFILES['wcag_sc'])
     for sc in data['wcag_sc'].values():
-        WCAG_SC(sc)
+        WcagSc(sc)
 
     # Set up guideline instances
     files = ls_dir(SRCDIR['guidelines'])
@@ -107,8 +107,8 @@ def main():
         data['faq_tags'] = json.loads(file_content)
     except Exception as e:
         handle_file_error(e, MISC_INFO_SRCFILES['faq_tags'])
-    for category_id, names in data['faq_tags'].items():
-        FAQ_Tag(category_id, names)
+    for tag_id, names in data['faq_tags'].items():
+        FaqTag(tag_id, names)
 
     # Set up FAQ instances
     files = ls_dir(SRCDIR['faq'])
@@ -118,7 +118,7 @@ def main():
         check_duplicate_values(data['faqs'], 'id', 'FAQ ID')
         check_duplicate_values(data['faqs'], 'sortKey', 'FAQ sortKey')
     for faq in data['faqs']:
-        FAQ(faq)
+        Faq(faq)
 
     rel = RelationshipManager()
     os.makedirs(DEST_DIRS['guidelines'], exist_ok=True)
@@ -141,24 +141,24 @@ def main():
             write_rst(templates['tool_example'], tool.example_template_object(LANG), destfile)
 
     os.makedirs(DEST_DIRS['faq_articles'], exist_ok=True)
-    for faq in FAQ.list_all():
+    for faq in Faq.list_all():
         filename = f'{faq.id}.rst'
         destfile = os.path.join(DEST_DIRS['faq_articles'], filename)
         if build_all or destfile in targets:
             write_rst(templates['faq_article'], faq.template_object(LANG), destfile)
 
     os.makedirs(DEST_DIRS['faq_tags'], exist_ok=True)
-    for tag in FAQ_Tag.list_all():
+    for tag in FaqTag.list_all():
         filename = f'{tag.id}.rst'
         destfile = os.path.join(DEST_DIRS['faq_tags'], filename)
         if tag.article_count() > 0 and build_all or destfile in targets:
             write_rst(templates['faq_tagpage'], tag.template_object(LANG), destfile)
 
-    sorted_tags = sorted(FAQ_Tag.list_all(), key=lambda x: x.names[LANG])
+    sorted_tags = sorted(FaqTag.list_all(), key=lambda x: x.names[LANG])
     tags = [tag.template_object(LANG) for tag in sorted_tags if tag.article_count() > 0]
     tagpages = [tagpage.template_object(LANG) for tagpage in sorted_tags if tagpage.article_count() > 0]
-    sorted_articles_by_date = FAQ.list_all(sort_by='date')
-    sorted_articles_by_sortkey = FAQ.list_all(sort_by='sortKey')
+    sorted_articles_by_date = Faq.list_all(sort_by='date')
+    sorted_articles_by_sortkey = Faq.list_all(sort_by='sortKey')
     if build_all or STATIC_FILES['faq_index'] in targets:
         articles = [article.template_object(LANG) for article in sorted_articles_by_date]
         write_rst(templates['faq_index'], {'articles': articles, 'tags': tags}, STATIC_FILES['faq_index'])
@@ -176,7 +176,7 @@ def main():
             filename = f'{info.ref}.rst'
             destfile = os.path.join(DEST_DIRS['info2gl'], filename)
             if build_all or destfile in targets:
-                sorted_guidelines = sorted(rel.get_info_to_guidelines(info), key=lambda item: item.sortKey)
+                sorted_guidelines = sorted(rel.get_info_to_guidelines(info), key=lambda item: item.sort_key)
                 guidelines = [guideline.get_category_and_id(LANG) for guideline in sorted_guidelines]
                 write_rst(templates['info_to_gl'], {'guidelines': guidelines}, destfile)
 
@@ -191,11 +191,11 @@ def main():
 
     os.makedirs(DEST_DIRS['misc'], exist_ok=True)
     if build_all or STATIC_FILES['wcag21mapping'] in targets:
-        sc_mapping = [sc.template_object(LANG) for sc in WCAG_SC.get_all().values() if len(rel.get_sc_to_guidelines(sc)) > 0]
+        sc_mapping = [sc.template_object(LANG) for sc in WcagSc.get_all().values() if len(rel.get_sc_to_guidelines(sc)) > 0]
         write_rst(templates['wcag21mapping'], {'mapping': sc_mapping}, STATIC_FILES['wcag21mapping'])
 
     if build_all or STATIC_FILES['priority_diff'] in targets:
-        diffs = [sc.template_object(LANG) for sc in WCAG_SC.get_all().values() if sc.level != sc.localPriority]
+        diffs = [sc.template_object(LANG) for sc in WcagSc.get_all().values() if sc.level != sc.local_priority]
         write_rst(templates['priority_diff'], {'diffs': diffs}, STATIC_FILES['priority_diff'])
 
     if build_all or STATIC_FILES['miscdefs'] in targets:
@@ -228,13 +228,13 @@ def main():
             makefile_vars_list['check_example_target'].append(destfile)
             build_depends.append({'target': destfile, 'depends': ' '.join(tool.get_dependency())})
 
-        for faq in FAQ.list_all():
+        for faq in Faq.list_all():
             filename = f'{faq.id}.rst'
             destfile = os.path.join(DEST_DIRS['faq_articles'], filename)
             makefile_vars_list['faq_article_target'].append(destfile)
             build_depends.append({'target': destfile, 'depends': ' '.join(faq.get_dependency())})
 
-        for tag in FAQ_Tag.list_all():
+        for tag in FaqTag.list_all():
             if tag.article_count() == 0:
                 continue
             filename = f'{tag.id}.rst'

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -357,7 +357,7 @@ def make_heading(title, level, className=""):
         return 2 if _isMultiByte(c) else 1
 
     def width(s):
-        return sum([_width(c) for c in s])
+        return sum(_width(c) for c in s)
 
     # Modify heading_styles accordingly
     heading_styles = [('#', True), ('*', True), ('=', False), ('-', False), ('^', False), ('"', False)]

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -5,7 +5,7 @@ import argparse
 import unicodedata
 import yaml
 from jsonschema import validate, ValidationError, RefResolver
-from jinja2 import Template, Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader
 from config import AVAILABLE_LANGUAGES, CHECK_TOOLS, SRCDIR, SCHEMA_FILENAMES, COMMON_SCHEMA_PATH, TEMPLATE_DIR, TEMPLATE_FILENAMES, MISC_INFO_SRCFILES, get_dest_dirnames, get_static_dest_files
 from a11y_guidelines import Category, WCAG_SC, InfoRef, Guideline, Check, FAQ, FAQ_Tag, CheckTool, RelationshipManager
 

--- a/tools/yaml2rst/yaml2rst.py
+++ b/tools/yaml2rst/yaml2rst.py
@@ -63,7 +63,7 @@ def main():
     # Setup CheckTool instances
     for tool_id, tool_names in CHECK_TOOLS.items():
         CheckTool(tool_id, tool_names)
-    
+
     # Set up check instances
     files = ls_dir(SRCDIR['checks'])
     makefile_vars['check_yaml'] = ' '.join(files)
@@ -72,15 +72,15 @@ def main():
         check_duplicate_values(data['checks'], 'id', 'Check ID')
     for check in data['checks']:
         Check(check)
-    
+
     # Set up guideline category instances
     try:
         file_content = read_file_content(MISC_INFO_SRCFILES['gl_categories'])
         data['categories'] = json.loads(file_content)
     except Exception as e:
         handle_file_error(e, MISC_INFO_SRCFILES['gl_categories'])
-    for id, names in data['categories'].items():
-        Category(id, names)
+    for category_id, names in data['categories'].items():
+        Category(category_id, names)
 
     # Set up WCAG SC instances
     try:
@@ -90,7 +90,7 @@ def main():
         handle_file_error(e, MISC_INFO_SRCFILES['wcag_sc'])
     for sc in data['wcag_sc'].values():
         WCAG_SC(sc)
-    
+
     # Set up guideline instances
     files = ls_dir(SRCDIR['guidelines'])
     makefile_vars['gl_yaml'] = ' '.join(files)
@@ -107,8 +107,8 @@ def main():
         data['faq_tags'] = json.loads(file_content)
     except Exception as e:
         handle_file_error(e, MISC_INFO_SRCFILES['faq_tags'])
-    for id, names in data['faq_tags'].items():
-        FAQ_Tag(id, names)
+    for category_id, names in data['faq_tags'].items():
+        FAQ_Tag(category_id, names)
 
     # Set up FAQ instances
     files = ls_dir(SRCDIR['faq'])
@@ -139,7 +139,7 @@ def main():
         destfile = os.path.join(DEST_DIRS['checks'], filename)
         if build_all or destfile:
             write_rst(templates['tool_example'], tool.example_template_object(LANG), destfile)
-        
+
     os.makedirs(DEST_DIRS['faq_articles'], exist_ok=True)
     for faq in FAQ.list_all():
         filename = f'{faq.id}.rst'
@@ -162,7 +162,7 @@ def main():
     if build_all or STATIC_FILES['faq_index'] in targets:
         articles = [article.template_object(LANG) for article in sorted_articles_by_date]
         write_rst(templates['faq_index'], {'articles': articles, 'tags': tags}, STATIC_FILES['faq_index'])
-        
+
     if build_all or STATIC_FILES['faq_tag_index'] in targets:
         write_rst(templates['faq_tag_index'], {'tags': tagpages}, STATIC_FILES['faq_tag_index'])
 
@@ -262,9 +262,9 @@ def main():
         write_rst(templates['makefile'], makefile_vars, destfile)
 
 
-def ls_dir(dir):
+def ls_dir(dirname):
     files = []
-    for currentDir, dirs, fs in os.walk(dir):
+    for currentDir, dirs, fs in os.walk(dirname):
         for f in fs:
             files.append(os.path.join(currentDir, f))
     return files
@@ -336,7 +336,7 @@ def process_yaml_file(file_path, schema_dir, schema_file, no_check, resolver):
         The processed YAML data with an additional source path.
     """
     data = read_yaml_file(file_path)
-    
+
     if not no_check:
         try:
             validate_data(data, os.path.join(schema_dir, schema_file), resolver)
@@ -349,19 +349,19 @@ def process_yaml_file(file_path, schema_dir, schema_file, no_check, resolver):
     return data
 
 def make_heading(title, level, className=""):
-    
+
     def _isMultiByte(c):
         return unicodedata.east_asian_width(c) in ['F', 'W', 'A']
-        
+
     def _width(c):
         return 2 if _isMultiByte(c) else 1
 
     def width(s):
         return sum([_width(c) for c in s])
-        
+
     # Modify heading_styles accordingly
     heading_styles = [('#', True), ('*', True), ('=', False), ('-', False), ('^', False), ('"', False)]
-    
+
     if not 1 <= level <= len(heading_styles):
         raise ValueError(f'Invalid level: {level}. Must be between 1 and {len(heading_styles)}')
 


### PR DESCRIPTION
- オブジェクト間の関係をRelationshipManagerクラスで一元管理するように変更
- Remove trailing white-spaces
- Rename variables pointed out by pylint
- 不要なelse/elifを削除
- 不要なメソッドの削除
- 不要なクラスのインポートを削除
- 条件反対などの一部記述を修正
- typo fix
- クラス名、変数名などを一般的な命名規則に合わせて変更
