### PR TITLE
Makeのfast path対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON?= python
-YAML2RST= $(PYTHON) tools/yaml2rst/yaml2rst.py
+YAML2RST= $(PYTHON) tools/yaml2rst/yaml2rst.py;
 
 # Minimal makefile for Sphinx documentation
 #


### PR DESCRIPTION
Make内のコマンド実行でPathがおかしくなる問題の対応。
参考：https://takasfz.hatenablog.com/entry/2022/04/05/215827