### PR TITLE
リンクをコピーするボタンの処理の改善

### DIFF
--- a/en/source/_static/copylink.js
+++ b/en/source/_static/copylink.js
@@ -1,17 +1,1 @@
-document.addEventListener('DOMContentLoaded', function () {
-  const buttonLabel = 'Copy Link';
-  const sections = document.querySelectorAll('section.permalink');
-
-  sections.forEach(section => {
-    const header = section.querySelector('h2');
-    if (header) {
-      const button = document.createElement('button');
-      button.textContent = buttonLabel;
-      button.className = 'copy-link';
-      button.onclick = function () {
-        navigator.clipboard.writeText(location.origin + location.pathname + '#' + section.id);
-      };
-      header.appendChild(button);
-    }
-  });
-});
+../../../ja/source/_static/copylink.js

--- a/en/source/_templates/layout.html
+++ b/en/source/_templates/layout.html
@@ -38,6 +38,9 @@
     <meta property="og:url" content="{{ theme_canonical_url }}{{ pagename }}{{ file_suffix }}" />
     <meta name="twitter:card" content="summary_large_image" />
   {% endif %}
+  <script>
+    var buttonLabel = 'Copy link';
+  </script>
   <script src="{{ pathto('_static/copylink.js', 1) }}"></script>
 {% endblock %}
 {% block content %}

--- a/ja/source/_static/copylink.js
+++ b/ja/source/_static/copylink.js
@@ -1,5 +1,4 @@
 document.addEventListener('DOMContentLoaded', function () {
-  const buttonLabel = 'リンクをコピー';
   function appendCopyButton(element, textToCopy) {
     const button = document.createElement('button');
     button.textContent = buttonLabel;

--- a/ja/source/_static/copylink.js
+++ b/ja/source/_static/copylink.js
@@ -1,17 +1,26 @@
 document.addEventListener('DOMContentLoaded', function () {
   const buttonLabel = 'リンクをコピー';
-  const sections = document.querySelectorAll('section.permalink');
+  function appendCopyButton(element, textToCopy) {
+    const button = document.createElement('button');
+    button.textContent = buttonLabel;
+    button.className = 'copy-link';
+    button.onclick = function () {
+      navigator.clipboard.writeText(textToCopy);
+    };
+    element.appendChild(button);
+  }
 
+  const firstH1 = document.querySelector('h1');
+  if (firstH1) {
+    appendCopyButton(firstH1, location.href);
+  }
+
+  const sections = document.querySelectorAll('section.permalink');
   sections.forEach(section => {
-    const header = section.querySelector('h2');
+    const header = section.querySelector('h2, h3, h4, h5, h6');
     if (header) {
-      const button = document.createElement('button');
-      button.textContent = buttonLabel;
-      button.className = 'copy-link';
-      button.onclick = function () {
-        navigator.clipboard.writeText(location.origin + location.pathname + '#' + section.id);
-      };
-      header.appendChild(button);
+      const urlToCopy = location.origin + location.pathname + '#' + section.id;
+      appendCopyButton(header, urlToCopy);  // sectionのIDを含むURLを使用
     }
   });
 });

--- a/ja/source/_templates/layout.html
+++ b/ja/source/_templates/layout.html
@@ -38,6 +38,9 @@
     <meta property="og:url" content="{{ theme_canonical_url }}{{ pagename }}{{ file_suffix }}" />
     <meta name="twitter:card" content="summary_large_image" />
   {% endif %}
+  <script>
+    var buttonLabel = 'リンクをコピー';
+  </script>
   <script src="{{ pathto('_static/copylink.js', 1) }}"></script>
 {% endblock %}
 {% block content %}

--- a/tools/yaml2rst/templates/axe-rules.rst
+++ b/tools/yaml2rst/templates/axe-rules.rst
@@ -22,7 +22,7 @@ Updated
 {% for rule in rules -%}
 .. _axe-rule-{{ rule.id }}:
 
-{% filter make_heading(2) -%}
+{% filter make_heading(2, 'permalink') -%}
 {%- if lang == 'ja' -%}
 {% if rule.translated is defined %}{{ rule.help.ja }} ({% endif -%}{{ rule.help.en }}{%- if rule.translated is defined %}){% endif %}
 {%- elif lang == 'en' -%}


### PR DESCRIPTION
- **ページの最初のh1、section.permalinkの最初のh2-h6にコピーリンクボタンを表示するように変更**
- **コピーボタンのラベルをテンプレートで指定するように変更**
- **英語版のcopylink.jsを日本語版へのsymlinkにして、ボタンのラベルをテンプレート内で定義。**
- **axe-coreのルールの見出しにコピーリンクボタンを設置**
