### PR TITLE
バージョン番号などの情報を日英で共通化

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -68,6 +68,10 @@ jobs:
         python-version: '3.9.x'
     - name: Install the Latest pip
       run: python -m pip install --upgrade pip
+    - name: install ja_JP.UTF-8 locale
+      run: |
+        sudo locale-gen ja_JP.UTF-8
+        sudo update-locale LANG=ja_JP.UTF-8
     - name: Install required modules
       run: python -m pip install -r requirements.txt --upgrade
     - name: Build HTML

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ap-northeast-1
 
+    - name: install ja_JP.UTF-8 locale
+      run: |
+        sudo locale-gen ja_JP.UTF-8
+        sudo update-locale LANG=ja_JP.UTF-8
+
     - name: Install the Latest pip
       run: python -m pip install --upgrade pip
 

--- a/en/source/conf.py
+++ b/en/source/conf.py
@@ -12,27 +12,29 @@
 #
 import os
 import sys
+sys.path.insert(0, os.path.abspath('../..'))
 sys.path.insert(0, os.path.abspath('.'))
 import datetime
 import re
+import locale
 
 # -- Project information -----------------------------------------------------
+from version import *
 
 project = 'freee Accessibility Guidelines'
 author = 'freee K.K.'
-guidelines_version = 'Ver. 202404.0'
-checksheet_version = '4.3.7'
-publishedDate = u'Apr 23 2024'
 guidelines_version_suffix = '-RELEASE'
 guidelines_version_date = ''
 
+locale.setlocale(locale.LC_TIME, 'en_US.UTF-8')
+date_obj = datetime.datetime.strptime(publishedDate, '%Y-%m-%d')
 if 'current' in tags:
   guidelines_version_suffix = '-CURRENT'
-  import datetime
-  guidelines_version_date = f'.{datetime.date.today().strftime("%Y%m%d")}'
-  today_str = datetime.date.today().strftime('%b %d %Y')
-  publishedDate = today_str
+  date_obj = datetime.date.today()
+  guidelines_version_date = f'.{date_obj.strftime("%Y%m%d")}'
 
+date_str = date_obj.strftime('%b %d %Y')
+publishedDate = date_str
 version = guidelines_version + guidelines_version_suffix + f'+{checksheet_version}'
 release = guidelines_version + guidelines_version_suffix + guidelines_version_date + f'+{checksheet_version}'
 guidelines_version_string = guidelines_version + guidelines_version_suffix + guidelines_version_date

--- a/en/source/conf.py
+++ b/en/source/conf.py
@@ -12,11 +12,11 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../..'))
-sys.path.insert(0, os.path.abspath('.'))
 import datetime
 import re
 import locale
+sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath('.'))
 
 # -- Project information -----------------------------------------------------
 from version import *

--- a/ja/source/conf.py
+++ b/ja/source/conf.py
@@ -14,6 +14,7 @@ import os
 import sys
 import datetime
 import re
+import locale
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from sphinx.util.docutils import SphinxDirective
@@ -28,6 +29,7 @@ author = 'フリー株式会社'
 guidelines_version_suffix = '-RELEASE'
 guidelines_version_date = ''
 
+locale.setlocale(locale.LC_TIME, 'ja_JP.UTF-8')
 date_obj = datetime.datetime.strptime(publishedDate, '%Y-%m-%d')
 if 'current' in tags:
   guidelines_version_suffix = '-CURRENT'

--- a/ja/source/conf.py
+++ b/ja/source/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+sys.path.insert(0, os.path.abspath('../..'))
 sys.path.insert(0, os.path.abspath('.'))
 import datetime
 import re
@@ -20,22 +21,21 @@ from docutils.parsers.rst import Directive
 from sphinx.util.docutils import SphinxDirective
 
 # -- Project information -----------------------------------------------------
+from version import *
 
 project = 'freeeアクセシビリティー・ガイドライン'
 author = 'フリー株式会社'
-guidelines_version = 'Ver. 202400.0'
-checksheet_version = '4.3.7'
-publishedDate = u'2024年4月23日'
 guidelines_version_suffix = '-RELEASE'
 guidelines_version_date = ''
 
+date_obj = datetime.datetime.strptime(publishedDate, '%Y-%m-%d')
 if 'current' in tags:
   guidelines_version_suffix = '-CURRENT'
-  import datetime
-  guidelines_version_date = f'.{datetime.date.today().strftime("%Y%m%d")}'
-  today_str = datetime.date.today().strftime('%Y年%-m月%-d日')
-  publishedDate = today_str
+  date_obj = datetime.date.today()
+  guidelines_version_date = f'.{date_obj.strftime("%Y%m%d")}'
 
+date_str = date_obj.strftime('%Y年%-m月%-d日')
+publishedDate = date_str
 version = guidelines_version + guidelines_version_suffix + f'+{checksheet_version}'
 release = guidelines_version + guidelines_version_suffix + guidelines_version_date + f'+{checksheet_version}'
 guidelines_version_string = guidelines_version + guidelines_version_suffix + guidelines_version_date

--- a/ja/source/conf.py
+++ b/ja/source/conf.py
@@ -12,13 +12,13 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../..'))
-sys.path.insert(0, os.path.abspath('.'))
 import datetime
 import re
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from sphinx.util.docutils import SphinxDirective
+sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath('.'))
 
 # -- Project information -----------------------------------------------------
 from version import *

--- a/version.py
+++ b/version.py
@@ -1,0 +1,3 @@
+guidelines_version = 'Ver. 202400.0'
+checksheet_version = '4.3.7'
+publishedDate = '2024-04-23'

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
-guidelines_version = 'Ver. 202400.0'
+guidelines_version = 'Ver. 202404.0'
 checksheet_version = '4.3.7'
 publishedDate = '2024-04-23'


### PR DESCRIPTION
- **バージョン情報をversion.pyに分離し、日英共通管理にする**
- **バージョン番号の誤りを修正**
- **import文を集約**
- **日本語版でも明示的にlocaleを設定**
