### PR TITLE
axe-coreを最新版に更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,11 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ap-northeast-1
 
+    - name: install ja_JP.UTF-8 locale
+      run: |
+        sudo locale-gen ja_JP.UTF-8
+        sudo update-locale LANG=ja_JP.UTF-8
+  
     - name: Install the Latest pip
       run: python -m pip install --upgrade pip
 


### PR DESCRIPTION
- **currentのビルドでもja_jp.utf-8ロケール追加**
- **参照するaxe-coreを2024-04-30時点のものに更新**
