### PR TITLE
yaml2x: 複数条件の出力時にカッコを用いて条件のグループを明示する

### DIFF
--- a/tools/yaml2x/a11y_guidelines/classes.py
+++ b/tools/yaml2x/a11y_guidelines/classes.py
@@ -730,7 +730,7 @@ class Condition:
             return f'{self.procedure.id}{language_info[lang]["simple_pass_singular"]}'
 
         simple_conditions = [cond.summary(lang) for cond in self.conditions if cond.type == 'simple']
-        complex_conditions = [cond.summary(lang) for cond in self.conditions if cond.type != 'simple']
+        complex_conditions = [f'({cond.summary(lang)})' for cond in self.conditions if cond.type != 'simple']
 
         if self.type == 'and':
             summary_separator = language_info[lang]['and_separator']

--- a/tools/yaml2x/a11y_guidelines/classes.py
+++ b/tools/yaml2x/a11y_guidelines/classes.py
@@ -743,7 +743,7 @@ class Condition:
 
         if len(simple_conditions) > 1:
             simple_conditions = [cond.replace(language_info[lang]['simple_pass_singular'], '') for cond in simple_conditions]
-            simple_summary = summary_separator.join(simple_conditions) + simple_pass
+            simple_summary = f'{summary_separator.join(simple_conditions)}{simple_pass}'
             return f'{simple_summary}{summary_connector}{summary_connector.join(complex_conditions)}' if complex_conditions else simple_summary
         else:
             return summary_connector.join(simple_conditions + complex_conditions)

--- a/tools/yaml2x/yaml2json/yaml2json.py
+++ b/tools/yaml2x/yaml2json/yaml2json.py
@@ -47,11 +47,11 @@ def deRST(condition, info):
         halfwidth_chars = r'[\u0000-\u007F\uFF61-\uFFDC\uFFE8-\uFFEE]'
 
         # Remove whitespaces between fullwidth chars
-        text = re.sub(f'({fullwidth_chars})\s+({fullwidth_chars})', r'\1\2', text)
+        text = re.sub(rf'({fullwidth_chars})\s+({fullwidth_chars})', r'\1\2', text)
 
         # Remove whitespaces between halfwidth chars and full width chars
-        text = re.sub(f'({fullwidth_chars})\s+({halfwidth_chars})', r'\1\2', text)
-        text = re.sub(f'({halfwidth_chars})\s+({fullwidth_chars})', r'\1\2', text)
+        text = re.sub(rf'({fullwidth_chars})\s+({halfwidth_chars})', r'\1\2', text)
+        text = re.sub(rf'({halfwidth_chars})\s+({fullwidth_chars})', r'\1\2', text)
 
         return text
 


### PR DESCRIPTION
- **Python's handling of escape chars is more strict now.**
- **Use parenthesis to note grouped conditions.**
- **Use f-strings for better readability.**
