### PR TITLE
reorganize checks related to modal dialogs.

### DIFF
--- a/data/yaml/checks/design/0155.yaml
+++ b/data/yaml/checks/design/0155.yaml
@@ -1,0 +1,31 @@
+id: '0155'
+sortKey: 100810
+severity: critical
+target: design
+platform:
+- web
+check:
+  ja: |-
+    モーダル・ダイアログがキーボードのみで操作できる設計になっている。
+  en: |-
+    The design allows modal dialogs to be operated using only the keyboard.
+conditions:
+- platform: web
+  type: or
+  conditions:
+  - type: simple
+    tool: misc
+    id: "0155-content-00"
+    procedure:
+      ja: |-
+        チェック対象の画面では、モーダル・ダイアログが表示されることはない。
+      en: |-
+        No modal dialog is displayed on the screen being checked.
+  - type: simple
+    tool: misc
+    id: "0155-content-01"
+    procedure:
+      ja: |-
+        モーダル・ダイアログが閉じた際、フォーカスがモーダル・ダイアログが開く直前の位置、またはそれに隣接した位置に戻るような設計になっていて、フォーカスが戻るべき位置が設計資料で明示されている。
+      en: |-
+        The design specifies that when the modal dialog is closed, the focus returns to the position immediately before the modal dialog was opened or to an adjacent position, and the position to which the focus should return is clearly indicated in the design documents.

--- a/data/yaml/checks/product/0171.yaml
+++ b/data/yaml/checks/product/0171.yaml
@@ -6,24 +6,16 @@ platform:
 - web
 check:
   ja: |-
-    :kbd:`Tab` / :kbd:`Shift+Tab` キーによるフォーカス移動時の挙動は以下のすべてを満たしている：
-
-    *  フォーカス・インジケーターまたはそれを代替する表示がある
-    *  自動的に次のような挙動が発生しない：
-
-       -  フォームの送信
-       -  レイアウトの変更
-       -  ページの遷移
-       -  モーダル・ダイアログの表示
-       -  表示内容の大幅な変更
+    キーボードによる操作時、常にフォーカス箇所が視覚的に確認できる
   en: |-
-    Behavior when moving focus using :kbd:`Tab` / :kbd:`Shift+Tab` keys fulfills all of the following
-
-    *  Focus indicator or alternative display is present
-    *  The following behaviors do not occur automatically:
-
-      -  Form Submission
-      -  Layout Changes
-      -  Page Transitions
-      -  Display of modal dialogs
-      -  Significant changes in displayed content
+    When operating with the keyboard, the focus position can always be visually confirmed.
+conditions:
+- platform: web
+  type: simple
+  tool: keyboard
+  id: "0171-keyboard-01"
+  procedure:
+    ja: |-
+      ページ先頭から :kbd:`Tab` キーでフォーカスを移動し、常にフォーカス位置を視覚的に確認できることを確認する。
+    en: |-
+      Confirm that the focus position can always be visually confirmed by moving the focus from the top of the page using the :kbd:`Tab` key.

--- a/data/yaml/checks/product/0173.yaml
+++ b/data/yaml/checks/product/0173.yaml
@@ -1,5 +1,5 @@
 id: '0173'
-sortKey: 501700
+sortKey: 501810
 severity: critical
 target: product
 platform:

--- a/data/yaml/checks/product/0173.yaml
+++ b/data/yaml/checks/product/0173.yaml
@@ -1,0 +1,33 @@
+id: '0173'
+sortKey: 501700
+severity: critical
+target: product
+platform:
+- web
+check:
+  ja: |-
+    キーボード操作時に、ユーザーが予期しない、またはユーザーの混乱を招くような表示の変化が自動的に発生しない。
+  en: |-
+    When operating with the keyboard, no unexpected or confusing display changes occur automatically.
+conditions:
+- platform: web
+  type: simple
+  tool: keyboard
+  id: "0173-keyboard-01"
+  procedure:
+    ja: |-
+      :kbd:`Tab` / :kbd:`Shift+Tab` キーによるフォーカス移動時に、自動的に次のような挙動が発生しない：
+
+      *  フォームの送信
+      *  レイアウトの変更
+      *  ページの遷移
+      *  モーダル・ダイアログの表示
+      *  表示内容の大幅な変更
+    en: |-
+      When moving focus with the :kbd:`Tab` / :kbd:`Shift+Tab` key, the following behaviors do not occur automatically:
+
+      *  Form submission
+      *  Layout changes
+      *  Page transitions
+      *  Modal dialog display
+      *  Significant changes in displayed content

--- a/data/yaml/checks/product/0174.yaml
+++ b/data/yaml/checks/product/0174.yaml
@@ -45,6 +45,6 @@ conditions:
       id: "0174-keyboard-03"
       procedure:
         ja: |-
-          モーダル・ダイアログが閉じた際、フォーカスはモーダル・ダイアログが開く直前の位置に戻る。
+          モーダル・ダイアログが閉じた際、フォーカスはモーダル・ダイアログが開く直前の位置、またはそれに隣接した位置に戻る。
         en: |-
-          When the modal dialog is closed, the focus returns to the position just before the modal dialog was opened.
+          When the modal dialog is closed, the focus returns to the position immediately before the modal dialog was opened or to an adjacent position.

--- a/data/yaml/checks/product/0174.yaml
+++ b/data/yaml/checks/product/0174.yaml
@@ -1,0 +1,49 @@
+id: '0174'
+sortKey: 502000
+severity: major
+target: product
+platform:
+- web
+check:
+  ja: |-
+    モーダル・ダイアログはキーボードのみで操作できる。
+  en: |-
+    Modal dialogs can be operated using only the keyboard.
+conditions:
+- platform: web
+  type: or
+  conditions:
+  - type: simple
+    tool: misc
+    id: 0174-content-00
+    procedure:
+      ja: |-
+        チェック対象の画面では、モーダル・ダイアログが表示されることはない。
+      en: |-
+        No modal dialog is displayed on the screen being checked.
+  - type: and
+    conditions:
+    - type: simple
+      tool: keyboard
+      id: "0174-keyboard-01"
+      procedure:
+        ja: |-
+          モーダル・ダイアログが表示された直後に :kbd:`Tab` キーを押下すると、フォーカスがモーダル・ダイアログ内に移動する。
+        en: |-
+          When the :kbd:`Tab` key is pressed immediately after a modal dialog is displayed, the focus moves into the modal dialog.
+    - type: simple
+      tool: keyboard
+      id: "0174-keyboard-02"
+      procedure:
+        ja: |-
+          モーダル・ダイアログ内で :kbd:`Tab` / :kbd:`Shift+Tab` キーを押してフォーカスを移動した際、フォーカスがモーダル・ダイアログの外に移動しない。
+        en: |-
+          When the focus is moved by pressing :kbd:`Tab` / :kbd:`Shift+Tab` within the modal dialog, the focus does not move outside of the modal dialog.
+    - type: simple
+      tool: keyboard
+      id: "0174-keyboard-03"
+      procedure:
+        ja: |-
+          モーダル・ダイアログが閉じた際、フォーカスはモーダル・ダイアログが開く直前の位置に戻る。
+        en: |-
+          When the modal dialog is closed, the focus returns to the position just before the modal dialog was opened.

--- a/data/yaml/checks/product/0174.yaml
+++ b/data/yaml/checks/product/0174.yaml
@@ -36,7 +36,8 @@ conditions:
       id: "0174-keyboard-02"
       procedure:
         ja: |-
-          モーダル・ダイアログ内で :kbd:`Tab` / :kbd:`Shift+Tab` キーを押してフォーカスを移動した際、フォーカスがモーダル・ダイアログの外に移動しない。
+          モーダル・ダイアログ内で、フォーカスがモーダル・ダイアログの最後の要素に移動するまで :kbd:`Tab` キーを押した後、再度 :kbd:`Tab` キーを押してもフォーカスはモーダル・ダイアログの外に出ない。
+          同様に、 :kbd:`Shift+Tab` キーを押してフォーカスがモーダル・ダイアログの最初の要素に移動した後、再度 :kbd:`Shift+Tab` キーを押してもフォーカスはモーダル・ダイアログの外に出ない。
         en: |-
           When the focus is moved by pressing :kbd:`Tab` / :kbd:`Shift+Tab` within the modal dialog, the focus does not move outside of the modal dialog.
     - type: simple

--- a/data/yaml/checks/product/0174.yaml
+++ b/data/yaml/checks/product/0174.yaml
@@ -1,5 +1,5 @@
 id: '0174'
-sortKey: 502000
+sortKey: 501820
 severity: major
 target: product
 platform:

--- a/data/yaml/checks/product/0201.yaml
+++ b/data/yaml/checks/product/0201.yaml
@@ -6,8 +6,7 @@ platform:
 - web
 check:
   ja: |-
-    *  :kbd:`Tab` / :kbd:`Shift+Tab` キーによるフォーカスの移動時、特定の箇所からフォーカスが抜け出せないような状況が発生しない、または
-    *  特定の箇所からフォーカスが抜け出せない状態では、矢印キーやEscキーの押下といった簡単な操作でその状態を抜け出すことができる
+    キーボードのみの操作で、フォーカスが特定の場所に閉じ込められるような状態が発生しない。
 
     特に注意が必要なコンポーネントの例：
 
@@ -15,27 +14,38 @@ check:
     *  ポップアップ・メニュー
     *  モーダル・ダイアログ
   en: |-
-    *  When moving the focus using :kbd:`Tab` / :kbd:`Shift+Tab` keys, the focus does not get stuck at certain location, or
-    *  If the focus gets stuck at certain location, simple operation such as pressing arrow keys or Esc key gets the focus away from the location
+    No situation occurs where the focus is trapped in a specific location when operating with the keyboard only.
 
-    Examples of components that require special caution:
+    Examples of components that require special attention:
 
-    *  audio and/or video players
-    *  pop-up menus
-    *  modal dialogs
+    *  Video or audio content players
+    *  Popup menus
+    *  Modal dialogs
 conditions:
 - platform: web
-  type: simple
-  tool: keyboard
-  id: "0201-keyboard-01"
-  procedure:
-    ja: |-
-      :kbd:`Tab` キーを使って、ページの先頭からフォーカスを順に移動したときの挙動は、以下を満たしている：
-
-      *  :kbd:`Tab` / :kbd:`Shift+Tab` キーを押下しても、特定の場所からフォーカスが抜け出せないような状況が発生しない、または
-      *  :kbd:`Tab` / :kbd:`Shift+Tab` キーの押下でフォーカスが抜け出せない場合に、矢印キーや :kbd:`Esc` キーなど、簡単なキー操作でフォーカスを当該箇所から外すことができる。
-    en: |-
-      Behavior when moving the focus sequentially from the top of the page using the :kbd:`Tab` key fulfills the following:
-
-      *  Pressing the :kbd:` / :kbd:`Shift+Tab` key does not cause a situation where the focus cannot escape from a specific location, or
-      *  If the focus cannot escape by pressing the :kbd:`Tab` / :kbd:`Shift+Tab` key, it is possible to remove the focus from the corresponding location with simple key operations such as the arrow keys or the :kbd:`Esc` key.
+  type: or
+  conditions:
+  - type: simple
+    tool: keyboard
+    id: "0201-keyboard-01"
+    procedure:
+      ja: |-
+        ページの先頭から、 :kbd:`Tab` キーを順に押してフォーカスを移動した際、特定の箇所から抜け出せないような状況が発生しない。
+      en: |-
+        When moving the focus sequentially from the top of the page using the :kbd:`Tab` key, no situation occurs where the focus cannot escape from a specific location.
+  - type: simple
+    tool: keyboard
+    id: "0201-keyboard-02"
+    procedure:
+      ja: |-
+        :kbd:`Tab` / :kbd:`Shift+Tab` キーの押下でフォーカスが抜け出せない場合に、矢印キーや :kbd:`Esc` キーなど、簡単なキー操作でフォーカスを当該箇所から外すことができる。
+      en: |-
+        If the focus cannot escape by pressing the :kbd:`Tab` / :kbd:`Shift+Tab` keys, it can be moved away from that location using simple key operations such as the arrow keys or the :kbd:`Esc` key.
+  - type: simple
+    tool: keyboard
+    id: "0201-keyboard-03"
+    procedure:
+      ja: |-
+        :kbd:`Tab` / :kbd:`Shift+Tab` キーの押下でフォーカスが抜け出せない場合に、そのコンポーネントを非表示にするためのボタンやメニューが存在し、キーボードのみで操作できる。
+      en: |-
+        If the focus cannot escape by pressing the :kbd:`Tab` / :kbd:`Shift+Tab` keys, there is a button or menu to hide that component, and it can be operated using only the keyboard.

--- a/data/yaml/checks/product/0561.yaml
+++ b/data/yaml/checks/product/0561.yaml
@@ -12,67 +12,65 @@ check:
     Headings are recognized by the screen reader as headings of the heading levels indicated in the design documents.
 conditions:
 - platform: web
-  type: or
+  type: and
   conditions:
   - type: simple
-    tool: misc
-    id: "0561-content-00"
+    tool: axe
+    id: "0561-axe-01"
     procedure:
       ja: |-
-        チェック対象は、モーダル・ダイアログで、設計資料で見出しが示されていない。
+        axe DevToolsで以下のいずれの問題も出ない。
+
+        *  :ref:`axe-rule-empty-heading`
+        *  :ref:`axe-rule-heading-order`
+        *  :ref:`axe-rule-page-has-heading-one`
       en: |-
-        The check target is a modal dialog where no headings are indicated in the design documents.
-  - type: and
+        None of the following issues is reported by axe DevTools.
+
+        *  :ref:`axe-rule-empty-heading`
+        *  :ref:`axe-rule-heading-order`
+        *  :ref:`axe-rule-page-has-heading-one`
+  - type: or
     conditions:
     - type: simple
-      tool: axe
-      id: "0561-axe-01"
+      tool: misc
+      id: "0561-content-00"
       procedure:
         ja: |-
-          axe DevToolsで以下のいずれの問題も出ない。
-
-          *  :ref:`axe-rule-empty-heading`
-          *  :ref:`axe-rule-heading-order`
-          *  :ref:`axe-rule-page-has-heading-one`
+          チェック対象は、モーダル・ダイアログで、設計資料で見出しが示されていない。
         en: |-
-          None of the following issues is reported by axe DevTools.
+          The check target is a modal dialog where no headings are indicated in the design documents.
+    - type: simple
+      tool: nvda
+      id: "0561-nvda-01"
+      procedure:
+        ja: |-
+          NVDAで以下の操作をして見出しリストを表示したとき、ページ中の見出しが過不足なく表示される。
 
-          *  :ref:`axe-rule-empty-heading`
-          *  :ref:`axe-rule-heading-order`
-          *  :ref:`axe-rule-page-has-heading-one`
-    - type: or
-      conditions:
-      - type: simple
-        tool: nvda
-        id: "0561-nvda-01"
-        procedure:
-          ja: |-
-            NVDAで以下の操作をして見出しリストを表示したとき、ページ中の見出しが過不足なく表示される。
+          1. ブラウズ・モードで要素リストを表示（ :kbd:`NVDA+F7` ）
+          2. 「種別」を「見出し」に設定（ :kbd:`Alt+H` ）
+        en: |-
+          All headings on the page are displayed appropriately when displaying the heading list by steps below with NVDA.
 
-            1. ブラウズ・モードで要素リストを表示（ :kbd:`NVDA+F7` ）
-            2. 「種別」を「見出し」に設定（ :kbd:`Alt+H` ）
-          en: |-
-            All headings on the page are displayed appropriately when displaying the heading list by steps below with NVDA.
+          1. Display the elements list in browse mode (:kbd:`NVDA+F7`)
+          2. Set the "Type" to "Headings" ():kbd:`Alt+H`)
+      YouTube:
+        id: Gi2M1A0PB_0
+        title: 見出し【NVDAでアクセシビリティー チェック】
+    - type: simple
+      tool: macos-vo
+      id: "0561-macvo-01"
+      procedure:
+        ja: |-
+          macOS VoiceOverで以下の操作をして見出しリストを表示したとき、ページ中の見出しが過不足なく表示される。
 
-            1. Display the elements list in browse mode (:kbd:`NVDA+F7`)
-            2. Set the "Type" to "Headings" ():kbd:`Alt+H`)
-        YouTube:
-          id: Gi2M1A0PB_0
-          title: 見出し【NVDAでアクセシビリティー チェック】
-      - type: simple
-        tool: macos-vo
-        id: "0561-macvo-01"
-        procedure:
-          ja: |-
-            macOS VoiceOverで以下の操作をして見出しリストを表示したとき、ページ中の見出しが過不足なく表示される。
+          1. :kbd:`VO+U` を押下してローターのメニューを表示
+          2. 「見出し」を選択
+        en: |-
+          All headings on the page are displayed appropriately when displaying the heading list by steps below with macOS VoiceOver.
 
-            1. :kbd:`VO+U` を押下してローターのメニューを表示
-            2. 「見出し」を選択
-          en: |-
-            All headings on the page are displayed appropriately when displaying the heading list by steps below with macOS VoiceOver.
-
-            1. Press :kbd:`VO+U` to display the rotor menu
-            2. Select "Headings"
+          1. Press :kbd:`VO+U` to display the rotor menu
+          2. Select "Headings"
 - platform: ios
   type: simple
   tool: ios-vo

--- a/data/yaml/checks/product/0561.yaml
+++ b/data/yaml/checks/product/0561.yaml
@@ -19,9 +19,9 @@ conditions:
     id: "0561-content-00"
     procedure:
       ja: |-
-        チェック対象は、見出しを含まないモーダル・ダイアログである。
+        チェック対象は、モーダル・ダイアログで、設計資料で見出しが示されていない。
       en: |-
-        The target of the check is a modal dialog that does not contain any headings.
+        The check target is a modal dialog where no headings are indicated in the design documents.
   - type: and
     conditions:
     - type: simple

--- a/data/yaml/checks/product/0682.yaml
+++ b/data/yaml/checks/product/0682.yaml
@@ -11,43 +11,53 @@ check:
     All content on the page is placed in the appropriate area indicated by ARIA landmarks.
 conditions:
 - platform: web
-  type: and
+  type: or
   conditions:
   - type: simple
-    tool: axe
-    id: "0682-axe-01"
+    tool: misc
+    id: "0682-content-00"
     procedure:
       ja: |-
-        画面上に表示されているコンテンツに対して、axe DevToolsで以下のいずれの問題も発生しない。（非表示箇所に対して以下の問題が発生しても、通常は問題ない。）
-
-        -  :ref:`axe-rule-landmark-banner-is-top-level`
-        -  :ref:`axe-rule-landmark-complementary-is-top-level`
-        -  :ref:`axe-rule-landmark-contentinfo-is-top-level`
-        -  :ref:`axe-rule-landmark-main-is-top-level`
-        -  :ref:`axe-rule-landmark-no-duplicate-banner`
-        -  :ref:`axe-rule-landmark-no-duplicate-contentinfo`
-        -  :ref:`axe-rule-landmark-no-duplicate-main`
-        -  :ref:`axe-rule-landmark-one-main`
-        -  :ref:`axe-rule-landmark-unique`
-        -  :ref:`axe-rule-region`
+        チェック対象はモーダル・ダイアログである。
       en: |-
-        None of the following issues is reported by axe DevTools against visible content.  (There usually is no problem if these issues are reported against hidden content.)
+        The check target is a modal dialog.
+  - type: and
+    conditions:
+    - type: simple
+      tool: axe
+      id: "0682-axe-01"
+      procedure:
+        ja: |-
+          画面上に表示されているコンテンツに対して、axe DevToolsで以下のいずれの問題も発生しない。（非表示箇所に対して以下の問題が発生しても、通常は問題ない。）
 
-        -  :ref:`axe-rule-landmark-banner-is-top-level`
-        -  :ref:`axe-rule-landmark-complementary-is-top-level`
-        -  :ref:`axe-rule-landmark-contentinfo-is-top-level`
-        -  :ref:`axe-rule-landmark-main-is-top-level`
-        -  :ref:`axe-rule-landmark-no-duplicate-banner`
-        -  :ref:`axe-rule-landmark-no-duplicate-contentinfo`
-        -  :ref:`axe-rule-landmark-no-duplicate-main`
-        -  :ref:`axe-rule-landmark-one-main`
-        -  :ref:`axe-rule-landmark-unique`
-        -  :ref:`axe-rule-region`
-  - type: simple
-    tool: Landmark Navigation via Keyboard or Pop-up
-    id: "0682-misc-01"
-    procedure:
-      ja: |-
-        `Landmark Navigation via Keyboard or Pop-up <https://matatk.agrip.org.uk/landmarks/>`__ をインストールしたブラウザーで表示した際、コンテンツのすべてのパーツが適切なARIAランドマークの領域に属している。
-      en: |-
-        Every part of the page content is contained in an appropriate ARIA landmark region when viewed using a browser with the `Landmark Navigation via Keyboard or Pop-up <https://matatk.agrip.org.uk/landmarks/>`__ extention installed.
+          -  :ref:`axe-rule-landmark-banner-is-top-level`
+          -  :ref:`axe-rule-landmark-complementary-is-top-level`
+          -  :ref:`axe-rule-landmark-contentinfo-is-top-level`
+          -  :ref:`axe-rule-landmark-main-is-top-level`
+          -  :ref:`axe-rule-landmark-no-duplicate-banner`
+          -  :ref:`axe-rule-landmark-no-duplicate-contentinfo`
+          -  :ref:`axe-rule-landmark-no-duplicate-main`
+          -  :ref:`axe-rule-landmark-one-main`
+          -  :ref:`axe-rule-landmark-unique`
+          -  :ref:`axe-rule-region`
+        en: |-
+          None of the following issues is reported by axe DevTools against visible content.  (There usually is no problem if these issues are reported against hidden content.)
+
+          -  :ref:`axe-rule-landmark-banner-is-top-level`
+          -  :ref:`axe-rule-landmark-complementary-is-top-level`
+          -  :ref:`axe-rule-landmark-contentinfo-is-top-level`
+          -  :ref:`axe-rule-landmark-main-is-top-level`
+          -  :ref:`axe-rule-landmark-no-duplicate-banner`
+          -  :ref:`axe-rule-landmark-no-duplicate-contentinfo`
+          -  :ref:`axe-rule-landmark-no-duplicate-main`
+          -  :ref:`axe-rule-landmark-one-main`
+          -  :ref:`axe-rule-landmark-unique`
+          -  :ref:`axe-rule-region`
+    - type: simple
+      tool: Landmark Navigation via Keyboard or Pop-up
+      id: "0682-misc-01"
+      procedure:
+        ja: |-
+          `Landmark Navigation via Keyboard or Pop-up <https://matatk.agrip.org.uk/landmarks/>`__ をインストールしたブラウザーで表示した際、コンテンツのすべてのパーツが適切なARIAランドマークの領域に属している。
+        en: |-
+          Every part of the page content is contained in an appropriate ARIA landmark region when viewed using a browser with the `Landmark Navigation via Keyboard or Pop-up <https://matatk.agrip.org.uk/landmarks/>`__ extention installed.

--- a/data/yaml/checks/product/0682.yaml
+++ b/data/yaml/checks/product/0682.yaml
@@ -11,48 +11,48 @@ check:
     All content on the page is placed in the appropriate area indicated by ARIA landmarks.
 conditions:
 - platform: web
-  type: or
+  type: and
   conditions:
   - type: simple
-    tool: misc
-    id: "0682-content-00"
+    tool: axe
+    id: "0682-axe-01"
     procedure:
       ja: |-
-        チェック対象はモーダル・ダイアログである。
+        画面上に表示されているコンテンツに対して、axe DevToolsで以下のいずれの問題も発生しない。（非表示箇所に対して以下の問題が発生しても、通常は問題ない。）
+
+        -  :ref:`axe-rule-landmark-banner-is-top-level`
+        -  :ref:`axe-rule-landmark-complementary-is-top-level`
+        -  :ref:`axe-rule-landmark-contentinfo-is-top-level`
+        -  :ref:`axe-rule-landmark-main-is-top-level`
+        -  :ref:`axe-rule-landmark-no-duplicate-banner`
+        -  :ref:`axe-rule-landmark-no-duplicate-contentinfo`
+        -  :ref:`axe-rule-landmark-no-duplicate-main`
+        -  :ref:`axe-rule-landmark-one-main`
+        -  :ref:`axe-rule-landmark-unique`
+        -  :ref:`axe-rule-region`
       en: |-
-        The check target is a modal dialog.
-  - type: and
+        None of the following issues is reported by axe DevTools against visible content.  (There usually is no problem if these issues are reported against hidden content.)
+
+        -  :ref:`axe-rule-landmark-banner-is-top-level`
+        -  :ref:`axe-rule-landmark-complementary-is-top-level`
+        -  :ref:`axe-rule-landmark-contentinfo-is-top-level`
+        -  :ref:`axe-rule-landmark-main-is-top-level`
+        -  :ref:`axe-rule-landmark-no-duplicate-banner`
+        -  :ref:`axe-rule-landmark-no-duplicate-contentinfo`
+        -  :ref:`axe-rule-landmark-no-duplicate-main`
+        -  :ref:`axe-rule-landmark-one-main`
+        -  :ref:`axe-rule-landmark-unique`
+        -  :ref:`axe-rule-region`
+  - type: or
     conditions:
     - type: simple
-      tool: axe
-      id: "0682-axe-01"
+      tool: misc
+      id: "0682-content-00"
       procedure:
         ja: |-
-          画面上に表示されているコンテンツに対して、axe DevToolsで以下のいずれの問題も発生しない。（非表示箇所に対して以下の問題が発生しても、通常は問題ない。）
-
-          -  :ref:`axe-rule-landmark-banner-is-top-level`
-          -  :ref:`axe-rule-landmark-complementary-is-top-level`
-          -  :ref:`axe-rule-landmark-contentinfo-is-top-level`
-          -  :ref:`axe-rule-landmark-main-is-top-level`
-          -  :ref:`axe-rule-landmark-no-duplicate-banner`
-          -  :ref:`axe-rule-landmark-no-duplicate-contentinfo`
-          -  :ref:`axe-rule-landmark-no-duplicate-main`
-          -  :ref:`axe-rule-landmark-one-main`
-          -  :ref:`axe-rule-landmark-unique`
-          -  :ref:`axe-rule-region`
+          チェック対象はモーダル・ダイアログである。
         en: |-
-          None of the following issues is reported by axe DevTools against visible content.  (There usually is no problem if these issues are reported against hidden content.)
-
-          -  :ref:`axe-rule-landmark-banner-is-top-level`
-          -  :ref:`axe-rule-landmark-complementary-is-top-level`
-          -  :ref:`axe-rule-landmark-contentinfo-is-top-level`
-          -  :ref:`axe-rule-landmark-main-is-top-level`
-          -  :ref:`axe-rule-landmark-no-duplicate-banner`
-          -  :ref:`axe-rule-landmark-no-duplicate-contentinfo`
-          -  :ref:`axe-rule-landmark-no-duplicate-main`
-          -  :ref:`axe-rule-landmark-one-main`
-          -  :ref:`axe-rule-landmark-unique`
-          -  :ref:`axe-rule-region`
+          The check target is a modal dialog.
     - type: simple
       tool: Landmark Navigation via Keyboard or Pop-up
       id: "0682-misc-01"

--- a/data/yaml/checks/product/0801.yaml
+++ b/data/yaml/checks/product/0801.yaml
@@ -14,37 +14,47 @@ check:
     *  The order of appearance of links and buttons within these components is the same on all pages/screens.
 conditions:
 - platform: web
-  type: and
+  type: or
   conditions:
   - type: simple
-    tool: keyboard
-    id: "0801-keyboard-01"
+    tool: misc
+    id: "0801-content-00"
     procedure:
       ja: |-
-        :kbd:`Tab` / :kbd:`Shift+Tab` キーでフォーカスを移動した際、複数のページで移動順序が一貫している。
+        チェック対象はモーダル・ダイアログである。
       en: |-
-        Focus moves in a consistent order across multiple pages when moving the focus using the :kbd:`Tab` / :kbd:`Shift+Tab` key.
-  - type: or
+        The check target is a modal dialog.
+  - type: and
     conditions:
     - type: simple
-      tool: nvda
-      id: "0801-nvda-01"
+      tool: keyboard
+      id: "0801-keyboard-01"
       procedure:
         ja: |-
-          NVDAのブラウズ・モードで上下矢印キーで読み上げさせたとき、複数のページで読み上げ順序が一貫している。
+          :kbd:`Tab` / :kbd:`Shift+Tab` キーでフォーカスを移動した際、複数のページで移動順序が一貫している。
         en: |-
-          The reading order is consistent across multiple pages when reading the content using the up/down arrow keys in NVDA's browse mode.
-      YouTube:
-        id: GYKStFpsfUw
-        title: 同じ出現順序【NVDAでアクセシビリティー チェック】
-    - type: simple
-      tool: macos-vo
-      id: "0801-macvo-01"
-      procedure:
-        ja: |-
-          macOS VoiceOverの :kbd:`VO` キーと左右矢印キーによるVoiceOverカーソルの操作で読み上げさせたとき、複数のページで読み上げ順序が一貫している。
-        en: |-
-          The reading order is consistent across multiple pages when reading the content using the :kbd:`VO` key and the left/right arrow keys to operate the VoiceOver cursor with macOS VoiceOver enabled.
+          Focus moves in a consistent order across multiple pages when moving the focus using the :kbd:`Tab` / :kbd:`Shift+Tab` key.
+    - type: or
+      conditions:
+      - type: simple
+        tool: nvda
+        id: "0801-nvda-01"
+        procedure:
+          ja: |-
+            NVDAのブラウズ・モードで上下矢印キーで読み上げさせたとき、複数のページで読み上げ順序が一貫している。
+          en: |-
+            The reading order is consistent across multiple pages when reading the content using the up/down arrow keys in NVDA's browse mode.
+        YouTube:
+          id: GYKStFpsfUw
+          title: 同じ出現順序【NVDAでアクセシビリティー チェック】
+      - type: simple
+        tool: macos-vo
+        id: "0801-macvo-01"
+        procedure:
+          ja: |-
+            macOS VoiceOverの :kbd:`VO` キーと左右矢印キーによるVoiceOverカーソルの操作で読み上げさせたとき、複数のページで読み上げ順序が一貫している。
+          en: |-
+            The reading order is consistent across multiple pages when reading the content using the :kbd:`VO` key and the left/right arrow keys to operate the VoiceOver cursor with macOS VoiceOver enabled.
 - platform: ios
   type: simple
   tool: ios-vo

--- a/data/yaml/checks/product/0861.yaml
+++ b/data/yaml/checks/product/0861.yaml
@@ -15,6 +15,14 @@ conditions:
   type: or
   conditions:
   - type: simple
+    tool: misc
+    id: "0861-content-00"
+    procedure:
+      ja: |-
+        チェック対象はモーダル・ダイアログである。
+      en: |-
+        The check target is a modal dialog.
+  - type: simple
     tool: nvda
     id: "0861-nvda-01"
     procedure:

--- a/data/yaml/checks/product/0862.yaml
+++ b/data/yaml/checks/product/0862.yaml
@@ -7,6 +7,26 @@ platform:
 - mobile
 check:
   ja: |-
-    グローバル・ナビゲーションやパンくずリスト内でそのページの位置が分かるような表示がされている。
+    グローバル・ナビゲーションやパンくずリスト内で、そのページが対応する要素が分かるような表示がされている。
   en: |-
-    There is a visual indication of the location of current page within the global navigation and the breadcrumb list.
+    The display indicates the elements corresponding to the current page within the global navigation and breadcrumb list.
+conditions:
+- platform: web
+  type: or
+  conditions:
+  - type: simple
+    tool: misc
+    id: "0862-content-00"
+    procedure:
+      ja: |-
+        チェック対象はモーダル・ダイアログである。
+      en: |-
+        The check target is a modal dialog.
+  - type: simple
+    tool: misc
+    id: "0862-content-01"
+    procedure:
+      ja: |-
+        グローバル・ナビゲーションやパンくずリスト内で、そのページが対応する要素が分かるような表示がされている。
+      en: |-
+        The display indicates the elements corresponding to the current page within the global navigation and breadcrumb list.

--- a/data/yaml/checks/product/1312.yaml
+++ b/data/yaml/checks/product/1312.yaml
@@ -6,14 +6,6 @@ platform:
 - web
 check:
   ja: |-
-    モーダル・ダイアログが表示される場合：
-
-    *  ユーザーの入力操作や情報の閲覧を妨げるようなタイミングで自動表示されない
-    *  キーボード操作でモーダル・ダイアログを開き:kbd:`Tab` キーを押下すると、フォーカスがモーダル・ダイアログ内に移動し、モーダル・ダイアログが閉じた際にはフォーカスが元の位置に戻る
-    *  モーダル・ダイアログ内で :kbd:`Tab` / :kbd:`Shift+Tab` キーを押してフォーカスを移動した際、フォーカスがモーダル・ダイアログの外に移動しない
+    ユーザーの入力操作や情報の閲覧を妨げるようなタイミングで自動表示されるモーダル・ダイアログはない。
   en: |-
-    Modal dialogs meet the following:
-
-    *  Does not appear automatically at a time that interferes with the user's input operations or viewing of information
-    *  Opening a modal dialog with a keyboard operation and pressing the :kbd:`Tab` key moves the focus into the modal dialog, and the focus returns to its original position when the modal dialog is closed
-    *  Focus does not move outside of a modal dialog when the focus is moved by pressing :kbd:`Tab` / :kbd:`Shift+Tab` within the modal dialog.
+    There are no modal dialogs that are automatically displayed at a timing that interferes with user input operations or information viewing.

--- a/data/yaml/gl/dynamic_content/focus.yaml
+++ b/data/yaml/gl/dynamic_content/focus.yaml
@@ -29,6 +29,6 @@ intent:
     Do not cause unexpected behavior for users with visual or cognitive impairments.
 checks:
 - '0152'
-- '0171'
+- '0173'
 info:
 - exp-tab-order-check

--- a/data/yaml/gl/form/dynamic-content-focus.yaml
+++ b/data/yaml/gl/form/dynamic-content-focus.yaml
@@ -21,7 +21,7 @@ intent:
     Do not cause behaviors that are unexpected for users with visual or cognitive impairments.
 checks:
 - '0152'
-- '0171'
+- '0173'
 info:
 - exp-form-dynamic-content
 - exp-tab-order-check

--- a/data/yaml/gl/input_device/focus.yaml
+++ b/data/yaml/gl/input_device/focus.yaml
@@ -22,5 +22,6 @@ intent:
     Ensure that users of assistive technologies such as screen readers and users who operate only with a keyboard can use content appropriately.
 checks:
 - '0172'
+- '0174'
 info:
 - exp-tab-order-check

--- a/data/yaml/gl/input_device/keyboard-operable.yaml
+++ b/data/yaml/gl/input_device/keyboard-operable.yaml
@@ -22,6 +22,7 @@ intent:
     Ensure that users with visual impairments or physical disabilities who cannot or do not use a mouse can use content.
 checks:
 - '0172'
+- '0174'
 - '0211'
 - '0231'
 - '0361'

--- a/data/yaml/gl/input_device/keyboard-operable.yaml
+++ b/data/yaml/gl/input_device/keyboard-operable.yaml
@@ -21,6 +21,7 @@ intent:
   en: |-
     Ensure that users with visual impairments or physical disabilities who cannot or do not use a mouse can use content.
 checks:
+- '0155'
 - '0172'
 - '0174'
 - '0211'


### PR DESCRIPTION
- **For check-0171, separate the focus indicator part and the keyboard operation part, and move latter into a new check 0173.**
- **Separate the focus management part of check-1312 into a new check-0174.**
- **Adjust the sortkey.**
- **Reword 0174-keyboard-02**
- **Be more specific about accepted behavior**
- **Add check-0155 to the design sheet, corresponds to check-0174 in product.**
- **reword 0174-keyboard-03**
- **States that these checks are irrelevant for modal dialogs: 0561, 0682, 0801, 0861, 0862**
- **Adjust the conditions for checks 0561, 0682.**
