### PR TITLE
クリエイティブ・コモンズ・ライセンスのバナー画像のalt属性の値を内容に沿うように修正した

### DIFF
--- a/en/source/intro/intro.rst
+++ b/en/source/intro/intro.rst
@@ -211,5 +211,5 @@ Updated:
 .. _WCAG21: https://www.w3.org/TR/WCAG21/
 
 .. |cclogo| image:: https://i.creativecommons.org/l/by/4.0/88x31.png
-   :alt: Creative Commons License
+   :alt: Creative Commons Attribution 4.0 International (CC BY 4.0) License
 

--- a/ja/source/intro/intro.rst
+++ b/ja/source/intro/intro.rst
@@ -212,6 +212,6 @@ Copyright © |copyright|
 .. _WCAG21ja: https://waic.jp/translations/WCAG21/
 
 .. |cclogo| image:: https://i.creativecommons.org/l/by/4.0/88x31.png
-   :alt: クリエイティブ・コモンズ・ライセンス
+   :alt: クリエイティブ・コモンズ 表示 国際 4.0 (CC BY 4.0) ライセンス
 
 .. translated:: true


### PR DESCRIPTION
[freeeアクセシビリティー・ガイドラインについて](https://a11y-guidelines.freee.co.jp/intro/intro.html) および、英訳版の [About freee Accessibility Guidelines](https://a11y-guidelines.freee.co.jp/en/intro/intro.html) に掲載しているクリエイティブ・コモンズ・ライセンスのバナー画像のalt属性の値を、画像の内容に沿うように修正しました。