### PR TITLE
チェック0562, 0591, 0922, 1191にmacOS VoiceOverでの確認手順を追加

### DIFF
--- a/data/yaml/checks/product/0562.yaml
+++ b/data/yaml/checks/product/0562.yaml
@@ -89,3 +89,33 @@ conditions:
     YouTube:
       id: lnW6TRgkBg0
       title: 表【NVDAでアクセシビリティー チェック】
+  - type: simple
+    tool: macos-vo
+    id: "0562-macvo-01"
+    procedure:
+      ja: |-
+        以下の手順で、ページ上のすべての表をmacOS VoiceOverで発見することができ、かつ、表中のセル間を移動して、セルの内容を適切に読み上げることができる。
+
+        *  表の発見：
+
+           -  :kbd:`VO+Command+T` で次の表に、 :kbd:`VO+Shift+Command+T` で前の表に移動する、または
+           -  :kbd:`VO+U` を押下してローターのメニューを表示し、「表」を選択して、ページ中のすべての表が過不足なく表示されることを確認する
+
+        *  表中のセル間を移動して、セルの内容を読み上げる：
+
+           1. 表にVoiceOverカーソルを移動し、 :kbd:`VO+Shift+↓` を押下して表の内部に入る
+           2. :kbd:`VO+←` / :kbd:`VO+→` / :kbd:`VO+↑` / :kbd:`VO+↓` でセル間を移動して、セルの内容を読み上げさせる
+           3. 確認が終わったら、 :kbd:`VO+Shift+↑` を押下して表の外に出る
+      en: |-
+        The following steps allow you to discover all tables on the page with macOS VoiceOver and move among cells within the tables to read the cell content properly.
+
+        *  Discovering tables:
+
+           -  Move to the next/previous table with :kbd:`VO+Command+T` / :kbd:`VO+Shift+Command+T`, or
+           -  Press :kbd:`VO+U` to display the rotor menu, select "Tables", and confirm that all tables on the page are listed
+
+        *  Moving among cells within tables and reading the cell contents:
+
+           1. Move the VoiceOver cursor onto the table, and press :kbd:`VO+Shift+↓` to interact with the table
+           2. Move among cells using :kbd:`VO+←` / :kbd:`VO+→` / :kbd:`VO+↑` / :kbd:`VO+↓` and have the cell contents announced
+           3. When done, press :kbd:`VO+Shift+↑` to stop interacting with the table

--- a/data/yaml/checks/product/0591.yaml
+++ b/data/yaml/checks/product/0591.yaml
@@ -43,3 +43,21 @@ conditions:
     YouTube:
       id: Wl6cydtXNw4
       title: 開閉するボタン【NVDAでアクセシビリティー チェック】
+  - type: simple
+    tool: macos-vo
+    id: "0591-macvo-01"
+    procedure:
+      ja: |-
+        以下のすべてを満たしていることをmacOS VoiceOverで確認：
+
+        *  :kbd:`VO+←` / :kbd:`VO+→` によるVoiceOverカーソルの操作でその部分を読み上げさせたとき、何らかの操作を受け付けるものであることが分かる
+        *  その部分で提供されているすべての機能を、最低限キーボードで操作できる
+        *  操作の結果表示が変わる場合、そのことが読み上げられる内容から理解できる
+        *  操作の結果表示が変わる場合、 :kbd:`VO+←` / :kbd:`VO+→` によるVoiceOverカーソルの操作で変更後の表示内容を読み上げさせて確認できる
+      en: |-
+        Confirm that all of the following are met using macOS VoiceOver:
+
+        *  Users can recognize that the component accepts some operation when reading the part by operating the VoiceOver cursor with :kbd:`VO+←` / :kbd:`VO+→`.
+        *  All of the functions provided in the part can be operated at least by keyboard.
+        *  If the displayed content changes upon operation, users can recognize it through the announcement.
+        *  If the displayed content changes upon operation, users can read the updated content by operating the VoiceOver cursor with :kbd:`VO+←` / :kbd:`VO+→`.

--- a/data/yaml/checks/product/0922.yaml
+++ b/data/yaml/checks/product/0922.yaml
@@ -12,17 +12,33 @@ check:
     The screen reader announces dates, times, numeric values, etc. in a way that is natural in the natural language used in the page or in the application.
 conditions:
 - platform: web
-  type: simple
-  tool: nvda
-  id: "0922-nvda-01"
-  procedure:
-    ja: |-
-      NVDAのブラウズ・モードで上下矢印キーを用いて日付、時刻、数値などを読み上げさせたとき、以下のすべてを満たしている。
+  type: or
+  conditions:
+  - type: simple
+    tool: nvda
+    id: "0922-nvda-01"
+    procedure:
+      ja: |-
+        NVDAのブラウズ・モードで上下矢印キーを用いて日付、時刻、数値などを読み上げさせたとき、以下のすべてを満たしている。
 
-      *  当該箇所の読み上げに用いられる音声は、他の箇所を読み上げさせたときの音声と同じ種類の音声である
-      *  当該箇所の読み上げが、そのページやアプリケーションで用いられている言語において自然なものになっている（例：日本語が用いられている場合に、「1月1日」を「ジャニュアリー ファースト」などと読み上げない）
-    en: |-
-      All of the following are met when reading date, time, number, etc. using up/down arrow keys in NVDA's browse mode.
+        *  当該箇所の読み上げに用いられる音声は、他の箇所を読み上げさせたときの音声と同じ種類の音声である
+        *  当該箇所の読み上げが、そのページやアプリケーションで用いられている言語において自然なものになっている（例：日本語が用いられている場合に、「1月1日」を「ジャニュアリー ファースト」などと読み上げない）
+      en: |-
+        All of the following are met when reading date, time, number, etc. using up/down arrow keys in NVDA's browse mode.
 
-      *  The voice used to read the part is the same as the voice used to read other parts.
-      *  The speech output of the part is natural and in line with the language used on the page or in the application.  (eg. "Jan 1" would not be read as "1月1日" if the primary language of the page is English.)
+        *  The voice used to read the part is the same as the voice used to read other parts.
+        *  The speech output of the part is natural and in line with the language used on the page or in the application.  (eg. "Jan 1" would not be read as "1月1日" if the primary language of the page is English.)
+  - type: simple
+    tool: macos-vo
+    id: "0922-macvo-01"
+    procedure:
+      ja: |-
+        macOS VoiceOverの :kbd:`VO+←` / :kbd:`VO+→` によるVoiceOverカーソルの操作で日付、時刻、数値などを読み上げさせたとき、以下のすべてを満たしている。
+
+        *  当該箇所の読み上げに用いられる音声は、他の箇所を読み上げさせたときの音声と同じ種類の音声である
+        *  当該箇所の読み上げが、そのページやアプリケーションで用いられている言語において自然なものになっている（例：日本語が用いられている場合に、「1月1日」を「ジャニュアリー ファースト」などと読み上げない）
+      en: |-
+        All of the following are met when reading date, time, number, etc. by operating the VoiceOver cursor with :kbd:`VO+←` / :kbd:`VO+→` using macOS VoiceOver.
+
+        *  The voice used to read the part is the same as the voice used to read other parts.
+        *  The speech output of the part is natural and in line with the language used on the page or in the application.  (eg. "Jan 1" would not be read as "1月1日" if the primary language of the page is English.)

--- a/data/yaml/checks/product/1191.yaml
+++ b/data/yaml/checks/product/1191.yaml
@@ -38,6 +38,19 @@ conditions:
     YouTube:
       id: 5YO_NxGuks8
       title: ステータスメッセージ【NVDAでアクセシビリティー チェック】
+  - type: simple
+    tool: macos-vo
+    id: "1191-macvo-01"
+    procedure:
+      ja: |-
+        macOS VoiceOverを起動した状態で設計資料に従ってステータス・メッセージが表示される操作を行ったとき、表示されたステータス・メッセージが自動的に読み上げられる。
+      en: |-
+        With macOS VoiceOver running, performing the operation to display status messages according to the design documents causes the displayed status messages to be automatically announced.
+    note:
+      ja: |-
+        参考： ``aria-live`` を用いた実装において期待される挙動については、 :ref:`exp-dynamic-content-status` に示した実装例を参照
+      en: |-
+        Note: Refer to the implementation example shown in :ref:`exp-dynamic-content-status` for the expected behavior in the implementation using ``aria-live``.
 - platform: ios
   type: simple
   tool: ios-vo


### PR DESCRIPTION
## 概要

Web向けにNVDAでの確認手順のみが定義されていたチェック項目のうち、macOS VoiceOverでも同等の確認が可能なものについて、macOS VoiceOverでの確認手順を追加しました。

## 対象チェック

| ID | 内容 |
|---|---|
| 0562 | スクリーン・リーダーによる表とセルの認識 |
| 0591 | 静的でないUI（リンク・ボタン・タブ等）のスクリーン・リーダー操作性 |
| 0922 | 日付・時刻・数値のページ／アプリケーションで用いられている言語における自然な読み上げ |
| 1191 | ステータス・メッセージの自動読み上げ |

## 対象外としたチェック

Web向けにNVDAのみが定義されているチェックのうち、以下の3件は「指定された言語の音声エンジンで読み上げられるか」を確認するものであり、macOS VoiceOverでは同等の確認方法が確立していないため対象外としました。

- 0621: 適切な言語の音声エンジンでの読み上げ
- 0921: 多言語混在テキストでの音声エンジン切替

## 実装内容

- 既存の `macvo-XX` 命名規則に合わせて `0562-macvo-01`, `0591-macvo-01`, `0922-macvo-01`, `1191-macvo-01` を追加
- 0922 は既存の `type: simple` から NVDA/macOS VoiceOver いずれかで確認できる `type: or` 構造に変更
- 手順は NVDA 版と同等の観点（読み上げ内容の確認・キーボードでの操作可否・変化の読み上げなど）に揃え、VoiceOver カーソル操作（`VO+←`/`VO+→`）・ローター（`VO+U`）・表内探索（`VO+Shift+↓`）など macOS VoiceOver のキー操作に置き換え

## 動作確認

- `ajv validate` で4ファイルすべてスキーマ検証済み
- pre-commit hook（lint-staged による ajv 検証）も通過